### PR TITLE
Feat: 하단 탭 아이콘을 누르면 아이콘 색 변경 및 페이지 이동 구현

### DIFF
--- a/src/components/tab/TapMenu.jsx
+++ b/src/components/tab/TapMenu.jsx
@@ -67,7 +67,7 @@ const menuRendering = (img) => {
     ];
     const imgIconFill = [homeImgFill, newsImgFill, postImg, profileImgFill];
     const tabTitle = ['홈', '소식', '게시물 작성', '프로필'];
-    const link = ['/', '/news', '/post', '/profile'];
+    const link = ['/', '/news', '/post/upload', '/profile'];
     for (let i = 0; i < 4; i++) {
         result.push(
             <StyledLink to={link[i]} key={i}>

--- a/src/components/tab/TapMenu.jsx
+++ b/src/components/tab/TapMenu.jsx
@@ -67,7 +67,7 @@ const menuRendering = (img) => {
     ];
     const imgIconFill = [homeImgFill, newsImgFill, postImg, profileImgFill];
     const tabTitle = ['홈', '소식', '게시물 작성', '프로필'];
-    const link = ['/', '/news', '/post/update', '/profile'];
+    const link = ['/', '/news', '/post', '/profile'];
     for (let i = 0; i < 4; i++) {
         result.push(
             <StyledLink to={link[i]} key={i}>

--- a/src/components/tab/TapMenu.jsx
+++ b/src/components/tab/TapMenu.jsx
@@ -4,62 +4,94 @@ import homeImg from '../../assets/icon-home.png';
 import newsImg from '../../assets/icon-message-circle.png';
 import postImg from '../../assets/icon-edit.png';
 import profileImg from '../../assets/icon-user.png';
+import homeImgFill from '../../assets/icon-home-fill.png';
+import newsImgFill from '../../assets/icon-message-circle-fill.png';
+import profileImgFill from '../../assets/icon-user-fill.png';
+import { Link } from 'react-router-dom';
 
-function TabNav() {
+const NavStyle = styled.section`
+    padding: 12px 6px 6px 6px;
+`;
+
+const Ul = styled.ul`
+    //reset
+    list-style: none;
+    padding: 0;
+    margin: 0 auto;
+
+    display: flex;
+    justify-content: space-between;
+    
+`;
+
+const StyledLink = styled(Link)`
+    text-decoration: none;
+    &:focus,
+    &:hover,
+    &:visited,
+    &:link,
+    &:active {
+        text-decoration: none;
+    }
+`;
+
+const Li = styled.li`
+    //reset
+    list-style: none;
+    padding: 0;
+    margin: 0 auto;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 60px;
+`;
+
+const Img = styled.img`
+    width: 24px;
+    height: 24px;
+`;
+
+const Span = styled.span`
+    font-size: 1rem;
+    color: #767676;
+`;
+
+const menuRendering = (img) => {
+    const result = [];
+    const imgIcon = [
+        { key: 'homeImg', value: homeImg },
+        { key: 'newsImg', value: newsImg },
+        { key: 'postImg', value: postImg },
+        { key: 'profileImg', value: profileImg },
+    ];
+    const imgIconFill = [homeImgFill, newsImgFill, postImg, profileImgFill];
+    const tabTitle = ['홈', '소식', '게시물 작성', '프로필'];
+    const link = ['/', '/news', '/post/update', '/profile'];
+    for (let i = 0; i < 4; i++) {
+        result.push(
+            <StyledLink to={link[i]} key={i}>
+                <Li key={i}>
+                    <Img
+                        src={imgIcon[i].key === img ? imgIconFill[i] : imgIcon[i].value}
+                        alt=""
+                    />
+                    <Span>{tabTitle[i]}</Span>
+                </Li>
+            </StyledLink>
+        );
+    }
+    return result;
+};
+
+function TabMenu({ img }) {
     return (
         <>
             <NavStyle className="buttom-nav">
-                <ul>
-                    <li>
-                        <img src={homeImg} alt="" />
-                        <span>홈</span>
-                    </li>
-                    <li>
-                        <img src={newsImg} alt="" />
-                        <span>소식</span>
-                    </li>
-                    <li>
-                        <img src={postImg} alt="" />
-                        <span>게시물 작성</span>
-                    </li>
-                    <li>
-                        <img src={profileImg} alt="" />
-                        <span>프로필</span>
-                    </li>
-                </ul>
+                <Ul>{menuRendering(img)}</Ul>
             </NavStyle>
         </>
     );
 }
 
-export default TabNav;
-
-const NavStyle = styled.section`
-    //reset
-    ul,
-    li {
-        list-style: none;
-        padding: 0;
-        margin: 0 auto;
-    }
-    //
-    padding: 12px 6px 6px 6px;
-    ul {
-        display: flex;
-        justify-content: space-between;
-    }
-    li {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        width: 60px;
-    }
-    img {
-        width: 24px;
-        height: 24px;
-    }
-    span {
-        font-size: 10px;
-        color: #767676;
-    }
-`;
+export default TabMenu;

--- a/src/components/tab/TapMenuMove.jsx
+++ b/src/components/tab/TapMenuMove.jsx
@@ -9,7 +9,7 @@ function TabMenuMove() {
                 <Route path="/" element={<TabMenu img={'homeImg'} />} />
                 <Route path="/news" element={<TabMenu img={'newsImg'} />} />
                 <Route
-                    path="/post"
+                    path="/post/upload"
                     element={<TabMenu img={'uploadImg'} />}
                 />
                 <Route

--- a/src/components/tab/TapMenuMove.jsx
+++ b/src/components/tab/TapMenuMove.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import TabMenu from './TapMenu';
+
+function TabMenuMove() {
+    return (
+        <>
+            <Routes>
+                <Route path="/" element={<TabMenu img={'homeImg'} />} />
+                <Route path="/news" element={<TabMenu img={'newsImg'} />} />
+                <Route
+                    path="/post/update"
+                    element={<TabMenu img={'uploadImg'} />}
+                />
+                <Route
+                    path="/profile"
+                    element={<TabMenu img={'profileImg'} />}
+                />
+            </Routes>
+        </>
+    );
+}
+
+export default TabMenuMove;

--- a/src/components/tab/TapMenuMove.jsx
+++ b/src/components/tab/TapMenuMove.jsx
@@ -9,7 +9,7 @@ function TabMenuMove() {
                 <Route path="/" element={<TabMenu img={'homeImg'} />} />
                 <Route path="/news" element={<TabMenu img={'newsImg'} />} />
                 <Route
-                    path="/post/update"
+                    path="/post"
                     element={<TabMenu img={'uploadImg'} />}
                 />
                 <Route


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [x] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

![하단 탭 메뉴](https://user-images.githubusercontent.com/67677374/178149721-344e19c4-d544-400b-af73-f7f873a27d7c.gif)

-   스타일 컴포넌트 세분화하여 수정
-   홈, 소식, 게시물 올리기, 프로필 페이지 선택시 채워진 아이콘으로 변경하기 기능 추가
-   TabMenuMove.jsx 부분에 path를 설정하였습니다.
-   TabMenuMove.jsx에서 props로 값을 보내 TabMenu.jsx에서 for문으로 list를 생성하고 props와 일치하는  li의 img가 fill 됩니다.

## 질문
- 스타일 컴포넌트 이름을 어떻게 적어야 할까요? 규칙이 필요할거 같은데 고민입니다.
- 게시물 올리기 부분은 원래 하단 탭이 안나오는 것인데 나오는 것이 나을까요?(현재는 나타나있는 상태입니다.)
  - 때문에 게시물 작성은 현재 아이콘이 없어서 이미지가 변하지 않습니다.
- 되는데로 코드를 작성해보았는데 잘 작성한건지 모르겠습니다. 혹시 더 나은 코드 작성 방법이 있다면 코멘트 해주시면 감사하겠습니다!
