### PR TITLE
DeginCSS: navbar와 메뉴탭에 구분을 위한 회색 테두리 추가

### DIFF
--- a/src/components/nav/TopBasicNav.jsx
+++ b/src/components/nav/TopBasicNav.jsx
@@ -8,6 +8,7 @@ const NavStyle = styled.section`
     justify-content: space-between;
     align-items: center;
     padding: 12px 12px 12px 13px;
+    border-bottom: 1px solid #DBDBDB;
 `;
 
 const NavButton = styled.button`

--- a/src/components/nav/TopMainNav.jsx
+++ b/src/components/nav/TopMainNav.jsx
@@ -7,6 +7,7 @@ const NavStyle = styled.section`
     justify-content: space-between;
     align-items: center;
     padding: 12px 16px;
+    border-bottom: 1px solid #dbdbdb;
 `;
 
 const NavButton = styled.button`

--- a/src/components/nav/TopSearchNav.jsx
+++ b/src/components/nav/TopSearchNav.jsx
@@ -7,6 +7,7 @@ const NavStyle = styled.section`
     justify-content: space-between;
     align-items: center;
     padding: 8px 16px 8px 13px;
+    border-bottom: 1px solid #dbdbdb;
 `;
 
 const NavButton = styled.button`

--- a/src/components/nav/TopUploadNav.jsx
+++ b/src/components/nav/TopUploadNav.jsx
@@ -7,6 +7,7 @@ const NavStyle = styled.section`
     justify-content: space-between;
     align-items: center;
     padding: 12px 12px 12px 13px;
+    border-bottom: 1px solid #dbdbdb;
 `;
 
 const NavButton = styled.button`

--- a/src/components/tab/TapMenu.jsx
+++ b/src/components/tab/TapMenu.jsx
@@ -11,6 +11,7 @@ import { Link } from 'react-router-dom';
 
 const NavStyle = styled.section`
     padding: 12px 6px 6px 6px;
+    border-top: 1px solid #dbdbdb;
 `;
 
 const Ul = styled.ul`


### PR DESCRIPTION
## 작업 분류

-   [ ] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [x] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

![grayBorder](https://user-images.githubusercontent.com/67677374/178532461-f802253d-5f05-4035-9e27-d1e0feb9ee96.png)

-   navbar와 메뉴탭에 구분을 위한 회색 테두리 추가
-   이전 css 구현 시 배경색이랑 구분이 잘 안가 하단 혹은 상단에 회색 선이 있는걸 발견하지 못해 지금 추가합니다.
