### PR TITLE
Feat: modal UI 구성 및 페이지 이동 링크 연결(예비 링크)

### DIFF
--- a/src/components/modal/LoginModal.jsx
+++ b/src/components/modal/LoginModal.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styles from './LoginModal.module.css';
+
+function LoginModal() {
+    return (
+        <>
+            <li className={styles.list}>
+                <Link to="/login">
+                    <button className={styles.login_btn}>
+                        이메일로 로그인
+                    </button>
+                </Link>
+            </li>
+            <li className={styles.list}>
+                <span className={styles.span}>
+                    <Link className={styles.link} to="/join">
+                        회원가입
+                    </Link>
+                </span>
+            </li>
+        </>
+    );
+}
+
+export default LoginModal;

--- a/src/components/modal/LoginModal.module.css
+++ b/src/components/modal/LoginModal.module.css
@@ -1,0 +1,33 @@
+.list {
+    padding: 14px 34px 14px 34px;
+    font-size: 1.4rem;
+    font-weight: bold;
+}
+
+.list .login_btn {
+    width: 100%;
+    height: 100%;
+    border: 1px solid var(--gray-color);
+    border-radius: 44px;
+    padding: 13px 0;
+    color: white;
+    background-color: var(--logo-black);
+    font-size: 1.4rem;
+    text-align: center;
+}
+
+.list .login_btn:hover {
+    cursor: pointer;
+}
+
+.list .span {
+    display: block;
+    margin: 20px auto 82px;
+    font-size: 1.2rem;
+    text-align: center;
+    color: var(--gray-color);
+}
+
+.list .span .link {
+    color: var(--gray-color);
+}

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import LoginModal from './LoginModal';
+import styles from './Modal.module.css';
+import PostModal from './PostModal';
+
+function Modal({ values }) {
+    return (
+        <section className={styles.modal_page}>
+            <h2 className="ir">모달창</h2>
+            <ul className={styles.modal_lists} values={values}>
+                {values[0] === 'login' ? (
+                    <LoginModal />
+                ) : (
+                    <PostModal values={values} />
+                )}
+            </ul>
+        </section>
+    );
+}
+
+export default Modal;

--- a/src/components/modal/Modal.module.css
+++ b/src/components/modal/Modal.module.css
@@ -1,0 +1,31 @@
+.modal_page {
+    background-color: rgba(0, 0, 0, 0.3);
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 100;
+}
+
+.modal_lists {
+    background-color: white;
+    border-radius: 10px 10px 0 0;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 36px 0 10px;
+}
+
+.modal_lists::before {
+    position: absolute;
+    content: '';
+    top: 16px;
+    left: 50%;
+    width: 50px;
+    height: 4px;
+    background-color: #dbdbdb;
+    border-radius: 5px;
+    transform: translateX(-50%);
+}

--- a/src/components/modal/PostModal.jsx
+++ b/src/components/modal/PostModal.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import styles from './PostModal.module.css';
+import { useNavigate } from 'react-router-dom';
+
+function PostModal({ values }) {
+    const navigate = useNavigate();
+
+    const setButton = (value, navigate) => {
+        switch (value) {
+            case '삭제':
+                //삭제 모달 띄우기
+                break;
+            case '수정':
+                //수정 페이지로 이동
+                navigate('/edit');
+                break;
+            case '신고하기':
+                //신고 모달 띄우기
+                break;
+            case '웹사이트에서 상품보기':
+                //웹사이트 상품 페이지로 이동
+                navigate('/');
+                break;
+            default:
+                console.log('error: value를 다시 확인해주세요.');
+        }
+    };
+    return (
+        <ul className={styles.modal_lists}>
+            {values.map((value, i) => {
+                return (
+                    <li className={styles.modal_list} key={i}>
+                        <button
+                            className={styles.modal_listBtn}
+                            onClick={() => {
+                                setButton(value, navigate);
+                            }}
+                        >
+                            {value}
+                        </button>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}
+
+export default PostModal;

--- a/src/components/modal/PostModal.module.css
+++ b/src/components/modal/PostModal.module.css
@@ -1,0 +1,15 @@
+.modal_list {
+    padding: 14px 26px 14px 26px;
+    font-size: 1.4rem;
+    font-weight: bold;
+}
+
+.modal_list .modal_listBtn {
+    width: 100%;
+    height: 100%;
+    font-weight: bold;
+    text-align: left;
+}
+.modal_list .modal_listBtn:hover {
+    cursor: pointer;
+}


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

modal UI 구성 및 페이지 클릭 시 이동 링크 연결 틀을 만드는 데 까지 마쳤습니다.

-   묘듈화 하여 합성컴포넌트로 만들었습니다.
-   ![image](https://user-images.githubusercontent.com/67677374/178961228-d35b847e-d85c-4c2e-8f6c-5d4aa24fa5c8.png)← 버튼 누를 시 나타는 모듈창 입니다.

|  로그인 모달창  |  기타 모달창  |
|:----:|:----:|
|![image](https://user-images.githubusercontent.com/67677374/178961673-545dbd0f-2bbb-40f4-a5c3-739d71e297d1.png)|![image](https://user-images.githubusercontent.com/67677374/178961466-445fcf05-ee38-4672-a0f7-afccf5eabe0d.png)|
  - 원래 피그마에는 로그인 부분에는 상단의 회색 막대가 없으나, 합성 컴포넌트로 작성하여 생겼습니다. 생각보다 에너지가 많이 들어가서 이 부분은 다른 기능을 다 구현하고 난 다음에 수정 하면 어떨까 생각하고 있습니다. 아니면 좋은 의견 있으면 적용하겠습니다!
-   ```<Modal values={['login']}></Modal>```, ```<Modal values={['삭제', '수정']}></Modal>``` 처럼 필요한 키워드를 작성하면 적용됩니다.
- Modal.jsx에서는 values로 전달되는 props가 ['login']인지 아닌지에 따라 나타내는 컴포넌트가 달라집니다.
- PostModal.jsx의 switch 문에서 버튼을 누르면 이동할 주소를 작성하면 됩니다. 현재는 비어있거나 임의의 주소로 구성해두었습니다.
  - 수정 버튼 클릭 시 console에 나타나는 경고문구는 현재 주소와 일치하는 Router가 없어서 발생한 경고문입니다.
