### PR TITLE
Feat: 팔로워 리스트 기능 추가 ...

### DIFF
--- a/src/components/FollowersList.jsx
+++ b/src/components/FollowersList.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import styles from './FollowersList.module.css';
+import TopBasicNav from './nav/TopBasicNav';
+import UserFollow from './UserFollow';
+
+function FollowersList() {
+  const [followers, setFollowers] = useState([]);
+  const token =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyY2JjNTJiODJmZGNjNzEyZjQzODgyOSIsImV4cCI6MTY2MjcxMjQ1MSwiaWF0IjoxNjU3NTI4NDUxfQ.bnhQqSrauikpfrLKP6OXl2HMdizZdeM1TclnNTr1OXk';
+
+  useEffect(() => {
+    axios
+      .get('https://mandarin.api.weniv.co.kr/profile/0002/follower', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/json',
+        },
+      })
+      .then((res) => {
+        // console.log(res);
+        setFollowers(res.data);
+        console.log(res);
+        // console.log(followers);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
+  console.log(followers);
+  const navTitle = 'Followers';
+  return (
+    <div className={styles.followers_page}>
+      <TopBasicNav styles={styles} navTitle={navTitle}></TopBasicNav>
+      <ul className={styles.user_follow_warp}>
+        {followers && followers.map((_, i) => {
+          console.log(followers[i]._id);
+          console.log(followers[0]._id);
+          return (
+            <>
+              <UserFollow styles={styles} followers={followers} i={i} key={followers[i]._id} />
+            </>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default FollowersList;

--- a/src/components/FollowersList.module.css
+++ b/src/components/FollowersList.module.css
@@ -1,0 +1,33 @@
+.followers_page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.top_nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0 ;
+}
+
+.user_follow_warp {
+  margin: 48px 16px 0;
+  padding-top: 24px;
+  padding-bottom: 60px;
+}
+
+.user_follow {
+  margin-bottom: 16px;
+}
+
+.user_follow:last-child {
+  margin-bottom: 0;
+}
+
+.tab_menu {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}

--- a/src/components/UserFollow.jsx
+++ b/src/components/UserFollow.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 // import basicProfileImg from '../assets/basic-profile-img-.png';
 
-function UserFollow({ followers, i, styles }) {
+function UserFollow({ followers, i }) {
     return (
-        <Li className={styles.user_follow}>
+        <Li >
             <ProfileImg src={followers[i].image} />
             <UserInfoWarp>
                 <UserName>{followers[i].accountname}</UserName>
@@ -21,6 +21,10 @@ const Li = styled.li`
     align-items: center;
     width: 100%;
     background-color: #fff;
+    margin-bottom: 16px;
+    &:last-child {
+        margin-bottom: 0;
+    }
 `;
 
 const ProfileImg = styled.img`

--- a/src/components/UserFollow.jsx
+++ b/src/components/UserFollow.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import styled from 'styled-components';
+// import basicProfileImg from '../assets/basic-profile-img-.png';
+
+function UserFollow({ followers, i, styles }) {
+    return (
+        <Li className={styles.user_follow}>
+            <ProfileImg src={followers[i].image} />
+            <UserInfoWarp>
+                <UserName>{followers[i].accountname}</UserName>
+                <UserEmail>{followers[i]._id}</UserEmail>
+            </UserInfoWarp>
+            {/* 버튼컴포넌트 추가 시 들어갈 자리 */}
+            {followers.isfollow === false ? <div>팔로우</div> : <div>취소</div>}
+        </Li>
+    );
+}
+
+const Li = styled.li`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    background-color: #fff;
+`;
+
+const ProfileImg = styled.img`
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    margin-right: 12px;
+`;
+
+const UserInfoWarp = styled.div`
+    width: 100%;
+    text-align: start;
+`;
+
+const UserName = styled.p`
+    font-size: 14px;
+    line-height: 17.53px;
+    color: #000;
+    margin: 0;
+`;
+
+const UserEmail = styled.span`
+    font-size: 12px;
+    line-height: 15.02px;
+    color: #767676;
+    margin: 0;
+`;
+
+export default UserFollow;

--- a/src/components/nav/TopBasicNav.jsx
+++ b/src/components/nav/TopBasicNav.jsx
@@ -3,10 +3,10 @@ import styled from 'styled-components';
 import iconArrowLeft from '../../assets/icon-arrow-left.png';
 import logoutDot from '../../assets/icon-more-vertical.png';
 
-function TopBasicNav({ navTitle, styles }) {
+function TopBasicNav({ navTitle}) {
     return (
     <>
-        <NavStyle className={styles.top_nav}>
+        <NavStyle>
             <Warpper>
                 <ArrowLeft />
                 <NavTitle>{navTitle}</NavTitle>
@@ -24,6 +24,10 @@ const NavStyle = styled.section`
     display: flex;
     justify-content: space-between;
     align-items: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0 ;
 `;
 
 const Warpper = styled.div`

--- a/src/components/nav/TopBasicNav.jsx
+++ b/src/components/nav/TopBasicNav.jsx
@@ -1,46 +1,61 @@
-import styled from 'styled-components';
 import React from 'react';
+import styled from 'styled-components';
 import iconArrowLeft from '../../assets/icon-arrow-left.png';
 import logoutDot from '../../assets/icon-more-vertical.png';
 
+function TopBasicNav({ navTitle, styles }) {
+    return (
+    <>
+        <NavStyle className={styles.top_nav}>
+            <Warpper>
+                <ArrowLeft />
+                <NavTitle>{navTitle}</NavTitle>
+            </Warpper>
+            {navTitle !== 'Followers' ? null : <BtnLogout />}
+        </NavStyle>
+    </>
+);
+}
+
 const NavStyle = styled.section`
+    width: 100%;
+    height: 48px;
+    background-color: #fff;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 12px 12px 12px 13px;
 `;
 
-const NavButton = styled.button`
-    //reset
-    border: initial;
-    background-color: initial;
+const Warpper = styled.div`
+    display: flex;
+    align-items: center;
+    margin-left: 16px;
 `;
 
-const ArrowLeftButton = styled(NavButton)`
+const ArrowLeft = styled.button`
     width: 22px;
     height: 22px;
     background-image: url(${iconArrowLeft});
     background-size: cover;
+    background-color: initial;
+    border: none;
+    flex-shrink: 0;
 `;
 
-const LogoutButton = styled(NavButton)`
+const NavTitle = styled.h1`
+    font-size: 14px;
+    margin: 0;
+    margin-left: 8px;
+`;
+
+const BtnLogout = styled.button`
     width: 24px;
     height: 24px;
+    margin-right: 12px;
     background-image: url(${logoutDot});
     background-size: cover;
+    background-color: initial;
+    border: none;
 `;
 
-function TopBasicNav() {
-    return (
-        <>
-            <NavStyle className="nav">
-                <ArrowLeftButton />
-                <LogoutButton />
-            </NavStyle>
-        </>
-    );
-}
-
 export default TopBasicNav;
-
-

--- a/src/components/tab/TabMenu.jsx
+++ b/src/components/tab/TabMenu.jsx
@@ -1,0 +1,103 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import styled from 'styled-components';
+import homeImg from '../../assets/icon-home.png';
+import newsImg from '../../assets/icon-message-circle.png';
+import postImg from '../../assets/icon-edit.png';
+import profileImg from '../../assets/icon-user.png';
+import homeImgFill from '../../assets/icon-home-fill.png';
+import newsImgFill from '../../assets/icon-message-circle-fill.png';
+import profileImgFill from '../../assets/icon-user-fill.png';
+import { Link, Outlet } from 'react-router-dom';
+
+const NavStyle = styled.section`
+    padding: 12px 6px 6px 6px;
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    left: 0;
+`;
+
+const Ul = styled.ul`
+    //reset
+    list-style: none;
+    padding: 0;
+    margin: 0 auto;
+
+    display: flex;
+    justify-content: space-between;
+    
+`;
+
+const StyledLink = styled(Link)`
+    text-decoration: none;
+    &:focus,
+    &:hover,
+    &:visited,
+    &:link,
+    &:active {
+        text-decoration: none;
+    }
+`;
+
+const Li = styled.li`
+    //reset
+    list-style: none;
+    padding: 0;
+    margin: 0 auto;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 60px;
+`;
+
+const Img = styled.img`
+    width: 24px;
+    height: 24px;
+`;
+
+const Span = styled.span`
+    font-size: 1rem;
+    color: #767676;
+`;
+
+const menuRendering = (img) => {
+    const result = [];
+    const imgIcon = [
+        { key: 'homeImg', value: homeImg },
+        { key: 'newsImg', value: newsImg },
+        { key: 'postImg', value: postImg },
+        { key: 'profileImg', value: profileImg },
+    ];
+    const imgIconFill = [homeImgFill, newsImgFill, postImg, profileImgFill];
+    const tabTitle = ['홈', '소식', '게시물 작성', '프로필'];
+    const link = ['/', '/news', '/post/upload', '/profile'];
+    for (let i = 0; i < 4; i++) {
+        result.push(
+            <StyledLink to={link[i]} key={i}>
+                <Li key={i}>
+                    <Img
+                        src={imgIcon[i].key === img ? imgIconFill[i] : imgIcon[i].value}
+                        alt=""
+                    />
+                    <Span>{tabTitle[i]}</Span>
+                </Li>
+            </StyledLink>
+        );
+    }
+    return result;
+};
+
+function TabMenu({ img }) {
+    return (
+        <>
+        <Outlet></Outlet>
+            <NavStyle className="buttom-nav">
+                <Ul>{menuRendering(img)}</Ul>
+            </NavStyle>
+        </>
+    );
+}
+
+export default TabMenu;

--- a/src/components/tab/TabMenu.jsx
+++ b/src/components/tab/TabMenu.jsx
@@ -23,7 +23,6 @@ const Ul = styled.ul`
     list-style: none;
     padding: 0;
     margin: 0 auto;
-
     display: flex;
     justify-content: space-between;
     
@@ -45,7 +44,6 @@ const Li = styled.li`
     list-style: none;
     padding: 0;
     margin: 0 auto;
-
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/tab/TabMenuMove.jsx
+++ b/src/components/tab/TabMenuMove.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import TabMenu from './TabMenu';
+import FollowersList from '../FollowersList';
+
+function TabMenuMove() {
+    return (
+        <>
+            <Routes>
+                <Route path="/" element={<TabMenu img={'homeImg'} />} />
+                <Route path="/news" element={<TabMenu img={'newsImg'} />} />
+                <Route
+                    path="/post/upload"
+                    element={<TabMenu img={'uploadImg'} />}
+                />
+                <Route
+                    path="/profile"
+                    element={<TabMenu img={'profileImg'} />}
+                >
+                    <Route path="followers" element={<FollowersList />} />
+                    </Route>
+            </Routes>
+        </>
+    );
+}
+
+export default TabMenuMove;

--- a/src/pages/FollowersList.jsx
+++ b/src/pages/FollowersList.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import styles from './FollowersList.module.css';
+import TopBasicNav from '../components/nav/TopBasicNav';
+import UserFollow from '../components/UserFollow';
+
+function FollowersList() {
+  const [followers, setFollowers] = useState([]);
+  const token =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyY2JjNTJiODJmZGNjNzEyZjQzODgyOSIsImV4cCI6MTY2MjcxMjQ1MSwiaWF0IjoxNjU3NTI4NDUxfQ.bnhQqSrauikpfrLKP6OXl2HMdizZdeM1TclnNTr1OXk';
+
+  useEffect(() => {
+    axios
+      .get('https://mandarin.api.weniv.co.kr/profile/0002/follower', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/json',
+        },
+      })
+      .then((res) => {
+        // console.log(res);
+        setFollowers(res.data);
+        console.log(res);
+        // console.log(followers);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
+  console.log(followers);
+  const navTitle = 'Followers';
+  return (
+    <div className={styles.followers_page}>
+      <TopBasicNav styles={styles} navTitle={navTitle}></TopBasicNav>
+      <ul className={styles.user_follow_warp}>
+        {followers && followers.map((_, i) => {
+          console.log(followers[i]._id);
+          console.log(followers[0]._id);
+          return (
+            <>
+              <UserFollow styles={styles} followers={followers} i={i} key={followers[i]._id} />
+            </>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default FollowersList;

--- a/src/pages/FollowersList.module.css
+++ b/src/pages/FollowersList.module.css
@@ -4,30 +4,8 @@
   height: 100vh;
 }
 
-.top_nav {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0 ;
-}
-
 .user_follow_warp {
   margin: 48px 16px 0;
   padding-top: 24px;
   padding-bottom: 60px;
-}
-
-.user_follow {
-  margin-bottom: 16px;
-}
-
-.user_follow:last-child {
-  margin-bottom: 0;
-}
-
-.tab_menu {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
 }

--- a/src/pages/FollowersList.module.css
+++ b/src/pages/FollowersList.module.css
@@ -1,0 +1,33 @@
+.followers_page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.top_nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0 ;
+}
+
+.user_follow_warp {
+  margin: 48px 16px 0;
+  padding-top: 24px;
+  padding-bottom: 60px;
+}
+
+.user_follow {
+  margin-bottom: 16px;
+}
+
+.user_follow:last-child {
+  margin-bottom: 0;
+}
+
+.tab_menu {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

팔로워리스트 기능 구현 및 스타일 적용, 라우터 적용 했습니다!
<img width="402" alt="스크린샷 2022-07-15 오후 7 22 23" src="https://user-images.githubusercontent.com/100986977/179205038-f471c727-c7e9-4539-851e-f0cd265fdbe1.png">


-   취소 부분은 나중에 버튼 컴포넌트가 만들어지면 수정할 예정입니다.
-   임시적으로 token을 직접 작성해 데이터를 불러오고 있습니다. 로그인 기능 구현되면 수정할 예정입니다.
- TopBasicNav에 Followers 텍스트를 나타낼 수 있게 수정했습니다. (Followings로 바꿀 수도 있게 만들어 뒀습니다.)
- TopBasicNav에 로그아웃 버튼(점 세개)가 follower following 페이지에는 나타나지 않아 우선 follower일 경우 나타나지 않도록 했습니다.
- 라우터는 nested routes를 사용했습니다.
- FollowersList에서 각각 컴포넌트를 조정하고 싶었는데 우선 props로 styles를 전달해 각각 컴포넌트를 조정했는데 혹시 다른 방법이 있다면 알려주세요!
- (추가) 원래 닉네임 밑에 이메일이 떠야하는데 받아오는 데이터 중에 없어서 우선 id값을 넣었습니다. 나중에 전체 유저 중에 아이디 값이 맞는 유저를 불러오는 것 같은 방식 밖에 생각이 안나는데 더 고민해보고 수정하겠습니다 :)