### PR TITLE
Feat: 개인 프로필 기능 추가 및 스타일 변경 ...

### DIFF
--- a/src/components/HomePost.jsx
+++ b/src/components/HomePost.jsx
@@ -91,6 +91,7 @@ const HomePostDate = styled.span`
 `;
 
 const HomePost = ({ postList, profileData, i }) => {
+    const postDate = new Date(postList[i].updatedAt);
     return (
         <>
             <HomePostLi>
@@ -111,8 +112,7 @@ const HomePost = ({ postList, profileData, i }) => {
                     <HeartBtn>{postList[i].heartCount}</HeartBtn>
                     <CommentBtn>{postList[i].commentCount}</CommentBtn>
                     <HomePostDate>
-                        {postList[i].updatedAt.toLocaleString('ko-KR')}
-                        {/* 한국 형식으로 바꿀 수 있도록 수정 */}
+                        {`${postDate.getFullYear()}년 ${postDate.getMonth()}월 ${postDate.getDate()}일`}
                     </HomePostDate>
                 </div>
             </HomePostLi>

--- a/src/components/HomePost.jsx
+++ b/src/components/HomePost.jsx
@@ -28,14 +28,14 @@ const UserWarp = styled.div`
 
 const HomePostName = styled.span`
     font-weight: 700;
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: 1.2;
     padding: 4px 80px 0 0;
 `;
 
 const HomePostId = styled.span`
     font-weight: 400;
-    font-size: 12px;
+    font-size: 1.2rem;
     line-height: 1.2;
     color: #767676;
     padding: 0 180px 16px 0;
@@ -51,7 +51,7 @@ const MoreIcon = styled.button`
 `;
 
 const HomePostTxt = styled.p`
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: 1.4;
 `;
 
@@ -86,7 +86,7 @@ const HomePostDate = styled.span`
     display: block;
     margin-bottom: 4px;
     color: #767676;
-    font-size: 10px;
+    font-size: 1rem;
     line-height: 1.2;
 `;
 

--- a/src/components/HomePost.jsx
+++ b/src/components/HomePost.jsx
@@ -1,28 +1,29 @@
 import React from 'react';
 import styled from 'styled-components';
-import profile from '../assets/basic-profile.png';
 import moreIcon from '../assets/s-icon-more-vertical.png';
-import sampleImg from '../assets/post-sample-image.png';
 import heartIcon from '../assets/icon-heart.png';
 import messageIcon from '../assets/icon-message-circle-1.png';
 
-const HomePostDiv = styled.div`
+const HomePostLi = styled.li`
     display: flex;
-    width: 358px;
-
-    /* 영역 구분 위해 임시로 넣음. 후에 빼기 */
-    border: 1px solid #767676;
+    max-width: 358px;
 `;
 
 const HomePostProfile = styled.img`
     width: 42px;
     height: 42px;
+    border-radius: 50%;
     padding-right: 12px;
 `;
 
 const FlexDiv = styled.div`
     display: flex;
     justify-content: space-between;
+`;
+
+const UserWarp = styled.div`
+    display: flex;
+    flex-direction: column;
 `;
 
 const HomePostName = styled.span`
@@ -54,6 +55,13 @@ const HomePostTxt = styled.p`
     line-height: 1.4;
 `;
 
+const HomePostImg = styled.img`
+    width: 304px;
+    height: 228px;
+    object-fit: cover;
+    border-radius: 10px;
+`;
+
 const HeartBtn = styled.button`
     width: 45px;
     height: 20px;
@@ -82,33 +90,32 @@ const HomePostDate = styled.span`
     line-height: 1.2;
 `;
 
-const HomePost = () => {
+const HomePost = ({ postList, profileData, i }) => {
     return (
         <>
-            <HomePostDiv>
+            <HomePostLi>
                 <div>
-                    <HomePostProfile src={profile} />
+                    <HomePostProfile src={profileData.image} />
                 </div>
                 <div>
                     <FlexDiv>
                         {/* 클릭시 해당 사용자 피드 목록으로 이동하도록 후에 처리 */}
-                        <div>
-                            <HomePostName>애월읍 위니브 감귤농장</HomePostName>
-                            <HomePostId>@weniv_Mandarin</HomePostId>
-                        </div>
+                        <UserWarp>
+                            <HomePostName>{profileData.username}</HomePostName>
+                            <HomePostId>{`@${profileData.accountname}`}</HomePostId>
+                        </UserWarp>
                         <MoreIcon />
                     </FlexDiv>
-                    <HomePostTxt>
-                        옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의
-                        위하여, 뿐이다. 이상의 청춘의 뼈 따뜻한 그들의 그와
-                        약동하다. 대고, 못할 넣는 풍부하게 뛰노는 인생의 힘있다.
-                    </HomePostTxt>
-                    <img src={sampleImg} alt="포스트 이미지" />
-                    <HeartBtn>58</HeartBtn>
-                    <CommentBtn>12</CommentBtn>
-                    <HomePostDate>2020년 10월 21일</HomePostDate>
+                    <HomePostTxt>{postList[i].content}</HomePostTxt>
+                    <HomePostImg src={postList[i].image} alt="포스트 이미지" />
+                    <HeartBtn>{postList[i].heartCount}</HeartBtn>
+                    <CommentBtn>{postList[i].commentCount}</CommentBtn>
+                    <HomePostDate>
+                        {postList[i].updatedAt.toLocaleString('ko-KR')}
+                        {/* 한국 형식으로 바꿀 수 있도록 수정 */}
+                    </HomePostDate>
                 </div>
-            </HomePostDiv>
+            </HomePostLi>
         </>
     );
 };

--- a/src/components/Product.js
+++ b/src/components/Product.js
@@ -27,7 +27,7 @@ const ProductImg = styled.img`
 `;
 
 const ProductName = styled.p`
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: 17.53px;
     color: #000;
     margin: 0;
@@ -35,7 +35,7 @@ const ProductName = styled.p`
 `;
 
 const ProductPrice = styled.span`
-    font-size: 12px;
+    font-size: 1.2rem;
     line-height: 15.02px;
     color: #212121;
 `;

--- a/src/components/Product.js
+++ b/src/components/Product.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import styled from 'styled-components';
 
-function Product() {
+function Product({ productList, i }) {
     return (
         <ContentWrap>
-            <ProductImg />
-            <ProductName>상품이름</ProductName>
-            <ProductPrice>상품 가격</ProductPrice>
+            <ProductImg src={productList[i].itemImage} />
+            <ProductName>{productList[i].itemName}</ProductName>
+            <ProductPrice>{`${productList[i].price.toLocaleString(
+                'ko-KR'
+            )}원`}</ProductPrice>
         </ContentWrap>
     );
 }
 
-const ContentWrap = styled.article`
+const ContentWrap = styled.li`
     width: fit-content;
     text-align: start;
     background-color: #fff;

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import styles from './Profile.module.css';
+
+function Profile({ profileData }) {
+    return (
+        <div className={styles.all_warpper}>
+            <div className={styles.top_warpper}>
+                <dl className={styles.num_warpper}>
+                    <dt className={styles.num}>{profileData.followerCount}</dt>
+                    <dd className={styles.num_title}>followers</dd>
+                </dl>
+                <img
+                    className={styles.profile_img}
+                    src={profileData.image}
+                    alt=""
+                />
+                <dl className={styles.num_warpper}>
+                    <dt className={styles.num}>{profileData.followingCount}</dt>
+                    <dd className={styles.num_title}>followings</dd>
+                </dl>
+            </div>
+            <p className={styles.user_name}>{profileData.username}</p>
+            <p className={styles.user_id}>{`@${profileData.accountname}`}</p>
+            <p className={styles.user_intro}>{profileData.intro}</p>
+            <ul className={styles.button_warp}>
+                <li>
+                    <button
+                        className={styles.circle_button}
+                        type="button"
+                    ></button>
+                </li>
+                <li>
+                    {/* 추후 버튼 컴포넌트로 수정할 코드 */}
+                    <div>팔로우</div>
+                </li>
+                <li>
+                    <button
+                        className={`${styles.circle_button} ${styles.shared}`}
+                    ></button>
+                </li>
+            </ul>
+        </div>
+    );
+}
+
+export default Profile;

--- a/src/components/Profile.module.css
+++ b/src/components/Profile.module.css
@@ -1,0 +1,80 @@
+.all_warpper {
+    min-width: 390px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 30px 0 26px;
+}
+
+.all_warpper .top_warpper {
+    display: flex;
+    text-align: center;
+}
+
+.top_warpper .num_warpper {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.num_warpper .num {
+    font-size: 18px;
+    line-height: 1.25;
+    color: #000;
+}
+
+.num_warpper .num_title {
+    font-size: 10px;
+    line-height: 1.2;
+}
+
+.top_warpper .profile_img {
+    width: 110px;
+    height: 110px;
+    border-radius: 50%;
+    margin: 0 41px 16px 37px;
+}
+
+.user_name {
+    font-size: 16px;
+    line-height: 1.25;
+    color: #000;
+    margin-bottom: 6px;
+}
+
+.user_id {
+    font-size: 12px;
+    line-height: 1.16;
+    color: var(--gray-color);
+    margin-bottom: 16px;
+}
+
+.user_intro {
+    font-size: 14px;
+    line-height: 1.25;
+    color: var(--gray-color);
+    margin-bottom: 24px;
+}
+
+.button_warp {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.button_warp .circle_button {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    border: 1px solid #dbdbdb;
+    background-color: #fff;
+    background-image: url(../assets/icon-message-circle-1.png);
+    background-size: 20px;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.button_warp .circle_button.shared {
+    background-image: url(../assets/icon-share.png);
+}

--- a/src/components/Profile.module.css
+++ b/src/components/Profile.module.css
@@ -19,13 +19,13 @@
 }
 
 .num_warpper .num {
-    font-size: 18px;
+    font-size: 1.8rem;
     line-height: 1.25;
     color: #000;
 }
 
 .num_warpper .num_title {
-    font-size: 10px;
+    font-size: 1rem;
     line-height: 1.2;
 }
 
@@ -37,21 +37,21 @@
 }
 
 .user_name {
-    font-size: 16px;
+    font-size: 1.6rem;
     line-height: 1.25;
     color: #000;
     margin-bottom: 6px;
 }
 
 .user_id {
-    font-size: 12px;
+    font-size: 1.2rem;
     line-height: 1.16;
     color: var(--gray-color);
     margin-bottom: 16px;
 }
 
 .user_intro {
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: 1.25;
     color: var(--gray-color);
     margin-bottom: 24px;

--- a/src/components/UserPost.jsx
+++ b/src/components/UserPost.jsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
-import profile from '../assets/basic-profile.png';
 import moreIcon from '../assets/s-icon-more-vertical.png';
-import sampleImg from '../assets/post-sample-image.png';
 import heartIcon from '../assets/icon-heart.png';
 import messageIcon from '../assets/icon-message-circle-1.png';
 
-const HomePostDiv = styled.div`
+const HomePostLi = styled.li`
     display: flex;
-    width: 358px;
-
-    /* 영역 구분 위해 임시로 넣음. 후에 빼기 */
-    border: 1px solid #767676;
+    max-width: 358px;
 `;
 
 const HomePostProfile = styled.img`
     width: 42px;
     height: 42px;
+    border-radius: 50%;
     padding-right: 12px;
 `;
 
@@ -25,16 +21,21 @@ const FlexDiv = styled.div`
     justify-content: space-between;
 `;
 
+const UserWarp = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
 const HomePostName = styled.span`
     font-weight: 700;
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: 1.2;
     padding: 4px 80px 0 0;
 `;
 
 const HomePostId = styled.span`
     font-weight: 400;
-    font-size: 12px;
+    font-size: 1.2rem;
     line-height: 1.2;
     color: #767676;
     padding: 0 180px 16px 0;
@@ -50,8 +51,15 @@ const MoreIcon = styled.button`
 `;
 
 const HomePostTxt = styled.p`
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: 1.4;
+`;
+
+const HomePostImg = styled.img`
+    width: 304px;
+    height: 228px;
+    object-fit: cover;
+    border-radius: 10px;
 `;
 
 const HeartBtn = styled.button`
@@ -78,37 +86,36 @@ const HomePostDate = styled.span`
     display: block;
     margin-bottom: 4px;
     color: #767676;
-    font-size: 10px;
+    font-size: 1rem;
     line-height: 1.2;
 `;
 
-const HomePost = () => {
+const HomePost = ({ postList, profileData, i }) => {
+    const postDate = new Date(postList[i].updatedAt);
     return (
         <>
-            <HomePostDiv>
+            <HomePostLi>
                 <div>
-                    <HomePostProfile src={profile} />
+                    <HomePostProfile src={profileData.image} />
                 </div>
                 <div>
                     <FlexDiv>
                         {/* 클릭시 해당 사용자 피드 목록으로 이동하도록 후에 처리 */}
-                        <div>
-                            <HomePostName>애월읍 위니브 감귤농장</HomePostName>
-                            <HomePostId>@weniv_Mandarin</HomePostId>
-                        </div>
+                        <UserWarp>
+                            <HomePostName>{profileData.username}</HomePostName>
+                            <HomePostId>{`@${profileData.accountname}`}</HomePostId>
+                        </UserWarp>
                         <MoreIcon />
                     </FlexDiv>
-                    <HomePostTxt>
-                        옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의
-                        위하여, 뿐이다. 이상의 청춘의 뼈 따뜻한 그들의 그와
-                        약동하다. 대고, 못할 넣는 풍부하게 뛰노는 인생의 힘있다.
-                    </HomePostTxt>
-                    <img src={sampleImg} alt="포스트 이미지" />
-                    <HeartBtn>58</HeartBtn>
-                    <CommentBtn>12</CommentBtn>
-                    <HomePostDate>2020년 10월 21일</HomePostDate>
+                    <HomePostTxt>{postList[i].content}</HomePostTxt>
+                    <HomePostImg src={postList[i].image} alt="포스트 이미지" />
+                    <HeartBtn>{postList[i].heartCount}</HeartBtn>
+                    <CommentBtn>{postList[i].commentCount}</CommentBtn>
+                    <HomePostDate>
+                        {`${postDate.getFullYear()}년 ${postDate.getMonth()}월 ${postDate.getDate()}일`}
+                    </HomePostDate>
                 </div>
-            </HomePostDiv>
+            </HomePostLi>
         </>
     );
 };

--- a/src/components/UserPost.jsx
+++ b/src/components/UserPost.jsx
@@ -90,7 +90,7 @@ const HomePostDate = styled.span`
     line-height: 1.2;
 `;
 
-const HomePost = ({ postList, profileData, i }) => {
+const UserPost = ({ postList, profileData, i }) => {
     const postDate = new Date(postList[i].updatedAt);
     return (
         <>
@@ -112,7 +112,9 @@ const HomePost = ({ postList, profileData, i }) => {
                     <HeartBtn>{postList[i].heartCount}</HeartBtn>
                     <CommentBtn>{postList[i].commentCount}</CommentBtn>
                     <HomePostDate>
-                        {`${postDate.getFullYear()}년 ${postDate.getMonth()}월 ${postDate.getDate()}일`}
+                        {`${postDate.getFullYear()}년 ${
+                            postDate.getMonth() + 1
+                        }월 ${postDate.getDate()}일`}
                     </HomePostDate>
                 </div>
             </HomePostLi>
@@ -120,4 +122,4 @@ const HomePost = ({ postList, profileData, i }) => {
     );
 };
 
-export default HomePost;
+export default UserPost;

--- a/src/pages/userprofile/UserProfile.jsx
+++ b/src/pages/userprofile/UserProfile.jsx
@@ -6,7 +6,7 @@ import styles from './UserProfile.module.css';
 import TopBasicNav from '../../components/nav/TopBasicNav';
 import Profile from '../../components/Profile';
 import Product from '../../components/Product';
-import HomePost from '../../components/HomePost';
+import UserPost from '../../components/UserPost';
 
 function UserProfile() {
     const [profileData, setProfileData] = useState({});
@@ -85,7 +85,7 @@ function UserProfile() {
                     {postList.map((_, i) => {
                         return (
                             // eslint-disable-next-line react/jsx-key
-                            <HomePost
+                            <UserPost
                                 postList={postList}
                                 i={i}
                                 profileData={profileData}

--- a/src/pages/userprofile/UserProfile.jsx
+++ b/src/pages/userprofile/UserProfile.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import axios from 'axios';
+import { useEffect } from 'react';
+import { useState } from 'react';
+import styles from './UserProfile.module.css';
+import TopBasicNav from '../../components/nav/TopBasicNav';
+import Profile from '../../components/Profile';
+import Product from '../../components/Product';
+import HomePost from '../../components/HomePost';
+
+function UserProfile() {
+    const [profileData, setProfileData] = useState({});
+    const token =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyY2JjNTJiODJmZGNjNzEyZjQzODgyOSIsImV4cCI6MTY2MjcxMjQ1MSwiaWF0IjoxNjU3NTI4NDUxfQ.bnhQqSrauikpfrLKP6OXl2HMdizZdeM1TclnNTr1OXk';
+
+    // 사용자프로필
+    useEffect(() => {
+        axios
+            .get('https://mandarin.api.weniv.co.kr/profile/0002', {
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-type': 'application/json',
+                },
+            })
+            .then((res) => {
+                setProfileData(res.data.profile);
+            })
+            .then((error) => {
+                console.log(error);
+            });
+    }, {});
+
+    // 상품리스트
+    const [productList, setProductList] = useState([]);
+    useEffect(() => {
+        axios
+            .get('https://mandarin.api.weniv.co.kr/product/0002', {
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-type': 'application/json',
+                },
+            })
+            .then((res) => {
+                setProductList(res.data.product);
+            })
+            .then((error) => {
+                console.log(error);
+            });
+    }, []);
+
+    // 게시글 목록
+    const [postList, setPostList] = useState([]);
+    useEffect(() => {
+        axios
+            .get('https://mandarin.api.weniv.co.kr/post/0002/userpost', {
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-type': 'application/json',
+                },
+            })
+            .then((res) => {
+                setPostList(res.data.post);
+            })
+            .then((error) => {
+                console.log(error);
+            });
+    }, []);
+    console.log(postList);
+    return (
+        <>
+            <TopBasicNav />
+            <Profile profileData={profileData} />
+            <section className={styles.product_section}>
+                <h2 className={styles.title}>판매 중인 상품</h2>
+                <ul className={styles.item_warp}>
+                    {productList.map((_, i) => {
+                        // eslint-disable-next-line react/jsx-key
+                        return <Product productList={productList} i={i} />;
+                    })}
+                </ul>
+            </section>
+            <section className={styles.post_section}>
+                <h2 className={styles.ir}>작성한 게시글</h2>
+                <ul className={styles.post_warp}>
+                    {postList.map((_, i) => {
+                        return (
+                            // eslint-disable-next-line react/jsx-key
+                            <HomePost
+                                postList={postList}
+                                i={i}
+                                profileData={profileData}
+                            />
+                        );
+                    })}
+                </ul>
+            </section>
+        </>
+    );
+}
+
+export default UserProfile;

--- a/src/pages/userprofile/UserProfile.module.css
+++ b/src/pages/userprofile/UserProfile.module.css
@@ -1,0 +1,36 @@
+/* 나중에 global.css에 넣는 것이 좋을 것 같아요 */
+.ir {
+    position: absolute;
+    clip: rect(0 0 0 0);
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+}
+
+.product_section {
+    width: 100%;
+    border-top: 0.5px solid #dbdbdb;
+    border-bottom: 0.5px solid #dbdbdb;
+    padding: 20px 0 20px 21px;
+    margin-bottom: 6px;
+}
+
+.product_section .title {
+    font-size: 16px;
+    line-height: 1.25;
+    margin-bottom: 16px;
+}
+
+.product_section .item_warp {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow: scroll;
+}
+
+.post_section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 16px 0 30px;
+}


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

![localhost_3000_(iPhone SE)](https://user-images.githubusercontent.com/100986977/179709488-4d295041-d037-4bef-b7c0-2e79d854f68c.png)

## 작업 내용

우선 0002@test.com 으로 개인 프로필 페이지를 구현하였습니다.

주요작업 내용
- 상단의 사용자의 프로필, 상품 리스트, 게시글 리스트는 모두 불러왔습니다.
- HomePost의 스타일을 조금 변경했습니다.
- 코드가 너무 길어질 것 같아 상단 프로필 부분을 따로 컴포넌트로 만들어주었습니다.

후순위로 미룬 작업
- hearted(하트를 눌렀는지) 가 false 이면 빈 하트 true면 빨간 하트로 구현하려고 했지만 생각보다 생각하는데 시간이 오래 들어가서 뒤로 미뤘습니다.
- 우선 라우터 연결은 하지 않았습니다. 그것까지 PR을 올려버리면 보기 어려우실 것 같아서 머지한 다음에 간단하게 바로 작업하겠습니다.
- ~날짜가 한국 식으로 년도 월 일 이 출력되게 시도해보았지만 되지 않아 뒤로 미뤘습니다. 제가 사용한 방법은 .toLocaleString("ko-KR")입니다. 혹시 알게 되신다면 공유해주시면 감사하겠습니다.~ **수정완료**
- 버튼 컴포넌트는 혹시 pull 받다가 작업이 꼬일까봐 추후에 추가하는 것으로 미뤘습니다.
- key값 에러와 기타 에러는 나중에 잡으려고 우선 무시하고 있습니다.
- 될지모르지만 본인의 프로필 계정을 여기서 삼항 연산자로 추가하려고 합니다! 로그인한 아이디 값과 들어간 프로필 아이디 값이 같으면 ? 타인의 프로필 버튼 : 본인 프로필 버튼 이런 식으로 진행하고자 합니다!

추가적으로 수정해야할 내용이 있다면 알려주시면 감사하겠습니다!
