### PR TITLE
Feat: 로그인 화면 UI 추가

### DIFF
--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -9,13 +9,17 @@ function Login() {
         <>
             <section className={styles.login_body}>
                 <Title title={'로그인'} />
-                <LoginInput title={'이메일'} />
-                <LoginInput title={'비밀번호'} />
+                <div className={styles.login_title}>
+                    <LoginInput title={'이메일'} type={'email'} />
+                    <LoginInput title={'비밀번호'} type={'password'} />
+                </div>
                 <button className={styles.login_btn}>
                     <span className={styles.login_span}>로그인</span>
                 </button>
                 <span className={styles.email_join}>
-                    <Link to={'/join'}>이메일로 회원가입</Link>
+                    <Link className={styles.email_join_link} to={'/join'}>
+                        이메일로 회원가입
+                    </Link>
                 </span>
             </section>
         </>

--- a/src/components/login/Login.module.css
+++ b/src/components/login/Login.module.css
@@ -1,6 +1,11 @@
 .login_body {
-    padding-right: 142px;
-    padding-left: 142px;
+    max-width: 80%;
+    min-width: 322px;
+    margin: 0 auto;
+}
+
+.login_title {
+    padding-top: 40px;
 }
 
 .login_btn {
@@ -8,8 +13,10 @@
     color: white;
     border-radius: 44px;
     margin-top: 14px;
+    margin-bottom: 20px;
     padding: 13px 0;
     width: 100%;
+    cursor: pointer;
 }
 
 .login_span {
@@ -17,4 +24,11 @@
 }
 
 .email_join {
+    font-size: 1.2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.email_join_link {
+    color: var(--gray-color);
 }

--- a/src/components/login/Title.module.css
+++ b/src/components/login/Title.module.css
@@ -1,5 +1,6 @@
 .title_area {
     font-size: 2.4rem;
     text-align: center;
-    padding: 40px 162px;
+    padding-top: 40px;
+    word-break: keep-all;
 }


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

- 로그인 화면 UI를 추가했습니다.     


[이미지]
<img width="321" alt="image" src="https://user-images.githubusercontent.com/76866502/179782165-0cbb5761-83b4-430a-9e7b-2d902bd0bbf3.png">
![responsive](https://user-images.githubusercontent.com/76866502/179782920-857c025c-7946-41c4-bb46-58bc21a5737d.gif)

- 최대한 가운데정렬을 맞추어서 반응형 시에도 레이아웃이 깨지지 않도록 하였습니다.   
- 상단에 '로그인, 이메일로 로그인'과 같이 텍스트만 바뀌고 다른 레이아웃은 반복된다고 판단되는 부분은
`Title.jsx`로 따로 빼서 컴포넌트화하여 재사용할 수 있도록 하였습니다.
- 먼저 만들어놓은 `LoginInput.jsx`에서 `props`로 title, placeholder, type을 전달해주어서, 
필요한 파일에서 받아서 각각 다른 타입의 input박스로 재사용할 수 있게 해놓았습니다.


