### PR TITLE
Feat: 댓글 리스트 불러오기

### DIFF
--- a/src/components/HomePostOnlyTxt.jsx
+++ b/src/components/HomePostOnlyTxt.jsx
@@ -1,42 +1,47 @@
 import React from 'react';
 import styled from 'styled-components';
-import profile from '../assets/basic-profile.png';
+// import profile from '../assets/basic-profile.png';
 import moreIcon from '../assets/s-icon-more-vertical.png';
-import heartIcon from '../assets/icon-heart.png';
-import messageIcon from '../assets/icon-message-circle-1.png';
+// import heartIcon from '../assets/icon-heart.png';
+// import messageIcon from '../assets/icon-message-circle-1.png';
 
 const HomePostDiv = styled.div`
     display: flex;
-    width: 358px;
-
-    /* 영역 구분 위해 임시로 넣음. 후에 빼기 */
-    border: 1px solid #767676;
+    // 중앙정렬 위해 너비 길이 지정, 나중에 rem으로 고치기
+    width: 390px;
+    margin: 0 auto 25px auto;
 `;
 
 const HomePostProfile = styled.img`
     width: 42px;
     height: 42px;
     padding-right: 12px;
+    border-radius: 50%;
+`;
+
+const Div = styled.div`
+    width: 100%;
 `;
 
 const FlexDiv = styled.div`
     display: flex;
     justify-content: space-between;
+    margin-bottom: 7px;
 `;
 
 const HomePostName = styled.span`
     font-weight: 700;
     font-size: 14px;
     line-height: 1.2;
-    padding: 4px 80px 0 0;
 `;
 
-const HomePostId = styled.span`
+const HomePostSpan = styled.span`
     font-weight: 400;
     font-size: 12px;
     line-height: 1.2;
     color: #767676;
     padding: 0 180px 16px 0;
+    margin-left: 5px;
 `;
 
 const MoreIcon = styled.button`
@@ -48,64 +53,93 @@ const MoreIcon = styled.button`
     cursor: pointer;
 `;
 
-const HomePostTxt = styled.p`
-    font-size: 14px;
-    line-height: 1.4;
-`;
+// const HomePostTxt = styled.p`
+//     font-size: 14px;
+//     line-height: 1.4;
+// `;
 
-const HeartBtn = styled.button`
-    width: 45px;
-    height: 20px;
-    background: url(${heartIcon}) no-repeat left / 18px 18px;
-    text-align: right;
-    border: none;
-    cursor: pointer;
-    color: #767676;
-`;
+// const HeartBtn = styled.button`
+//     width: 45px;
+//     height: 20px;
+//     background: url(${heartIcon}) no-repeat left / 18px 18px;
+//     text-align: right;
+//     border: none;
+//     cursor: pointer;
+//     color: #767676;
+// `;
 
-const CommentBtn = styled.button`
-    width: 45px;
-    height: 20px;
-    margin: 3px 206px 15px 8px;
-    background: url(${messageIcon}) no-repeat left / 18px 18px;
-    text-align: right;
-    border: none;
-    cursor: pointer;
-    color: #767676;
-`;
-const HomePostDate = styled.span`
-    display: block;
-    margin-bottom: 4px;
-    color: #767676;
-    font-size: 10px;
-    line-height: 1.2;
-`;
+// const CommentBtn = styled.button`
+//     width: 45px;
+//     height: 20px;
+//     margin: 3px 206px 15px 8px;
+//     background: url(${messageIcon}) no-repeat left / 18px 18px;
+//     text-align: right;
+//     border: none;
+//     cursor: pointer;
+//     color: #767676;
+// `;
 
-const HomePostOnlyTxt = () => {
+// const HomePostDate = styled.span`
+//     display: block;
+//     margin-bottom: 4px;
+//     color: #767676;
+//     font-size: 10px;
+//     line-height: 1.2;
+// `;
+
+const HomePostOnlyTxt = ({ profileImg, name, time, children }) => {
+    // 작성 시간 계산 함수
+    const getTimeGap = (createTime) => {
+        const today = new Date();
+        const timeValue = new Date(createTime);
+
+        const betweenTime = Math.floor(
+            (today.getTime() - timeValue.getTime()) / 1000 / 60
+        );
+        if (betweenTime < 1) return '방금 전';
+        if (betweenTime < 60) {
+            return `${betweenTime}분 전`;
+        }
+
+        const betweenTimeHour = Math.floor(betweenTime / 60);
+        if (betweenTimeHour < 24) {
+            return `${betweenTimeHour}시간 전`;
+        }
+
+        const betweenTimeDay = Math.floor(betweenTime / 60 / 24);
+        if (betweenTimeDay < 365) {
+            return `${betweenTimeDay}일 전`;
+        }
+
+        return `${Math.floor(betweenTimeDay / 365)}년 전`;
+    };
+
     return (
         <>
             <HomePostDiv>
                 <div>
-                    <HomePostProfile src={profile} />
+                    <HomePostProfile src={profileImg} />
                 </div>
-                <div>
+                <Div>
                     <FlexDiv>
                         {/* 클릭시 해당 사용자 피드 목록으로 이동하도록 후에 처리 */}
-                        <div>
-                            <HomePostName>애월읍 위니브 감귤농장</HomePostName>
-                            <HomePostId>@weniv_Mandarin</HomePostId>
-                        </div>
+                        <Div>
+                            <HomePostName>{name}</HomePostName>
+                            <HomePostSpan> · {getTimeGap(time)}</HomePostSpan>
+                        </Div>
+                        {/* 사용자 정보에 따라 이 부분 클릭시 다른 모달*/}
                         <MoreIcon />
                     </FlexDiv>
-                    <HomePostTxt>
+                    {/* <HomePostTxt>
                         옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의
                         위하여, 뿐이다. 이상의 청춘의 뼈 따뜻한 그들의 그와
                         약동하다. 대고, 못할 넣는 풍부하게 뛰노는 인생의 힘있다.
                     </HomePostTxt>
                     <HeartBtn>58</HeartBtn>
                     <CommentBtn>12</CommentBtn>
-                    <HomePostDate>2020년 10월 21일</HomePostDate>
-                </div>
+                    <HomePostDate>2020년 10월 21일</HomePostDate> */}
+                    {children}
+                </Div>
             </HomePostDiv>
         </>
     );

--- a/src/components/HomePostOnlyTxt.jsx
+++ b/src/components/HomePostOnlyTxt.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-// import profile from '../assets/basic-profile.png';
 import moreIcon from '../assets/s-icon-more-vertical.png';
 // import heartIcon from '../assets/icon-heart.png';
 // import messageIcon from '../assets/icon-message-circle-1.png';
@@ -40,7 +39,6 @@ const HomePostSpan = styled.span`
     font-size: 12px;
     line-height: 1.2;
     color: #767676;
-    padding: 0 180px 16px 0;
     margin-left: 5px;
 `;
 
@@ -88,7 +86,7 @@ const MoreIcon = styled.button`
 // `;
 
 const HomePostOnlyTxt = ({ profileImg, name, time, children }) => {
-    // 작성 시간 계산 함수
+    // 작성 시간 계산 함수. 나중에 util로 빼기
     const getTimeGap = (createTime) => {
         const today = new Date();
         const timeValue = new Date(createTime);

--- a/src/components/comment/CommentList.jsx
+++ b/src/components/comment/CommentList.jsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+import HomePostOnlyTxt from '../HomePostOnlyTxt';
+import axios from 'axios';
+// import profile from '../../assets/basic-profile.png';
+// 프로필, name, 시간 :
+// comment content
+
+const CommentList = () => {
+    // 로그인 기능 구현 전이라 임시로 토큰과 게시글 설정
+    const [commentList, setCommentList] = useState([]);
+    const postId = '62d6321482fdcc712f4d5861';
+
+    useEffect(() => {
+        async function renderComments() {
+            const url = 'https://mandarin.api.weniv.co.kr';
+            const token =
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyZDU1NDNkODJmZGNjNzEyZjRjZjMyYiIsImV4cCI6MTY2MzQyMzY1NSwiaWF0IjoxNjU4MjM5NjU1fQ.Ic1go5YPFzLsfpS1UZJdfQePbGTDdubi8VEl_jmdd5A';
+            localStorage.setItem('token', token);
+            const getToken = localStorage.getItem('token');
+
+            try {
+                const res = await axios.get(`${url}/post/${postId}/comments`, {
+                    method: 'GET',
+                    headers: {
+                        'Authorization': `Bearer ${getToken}`,
+                        'Content-type': 'application/json',
+                    },
+                });
+                setCommentList(res.data.comments);
+                // console.log(res.data.comments);
+            } catch (error) {
+                console.log(error);
+            }
+        }
+        renderComments();
+    }, [commentList]);
+
+    return (
+        <>
+            {commentList &&
+                commentList.map((comment) => {
+                    return (
+                        <HomePostOnlyTxt
+                            profileImg={comment?.author?.image}
+                            name={comment?.author?.username}
+                            key={comment?.id}
+                            time={comment?.createdAt}
+                        >
+                            <div>{comment?.content}</div>
+                        </HomePostOnlyTxt>
+                    );
+                })}
+        </>
+    );
+};
+
+export default CommentList;

--- a/src/components/comment/TestPost.jsx
+++ b/src/components/comment/TestPost.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import CommentList from './CommentList';
+
+const TestPost = () => {
+    const [content, setContent] = useState('');
+    // const postId = '62d5543d82fdcc712f4cf32b';
+
+    // 현재 로그인 기능이 없어 임시로 사용자와 토큰을 설정했습니다
+    // 나중에 지우면 되는 테스트 페이지
+    const renderPost = async () => {
+        const url = 'https://mandarin.api.weniv.co.kr';
+        const token =
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyZDU1NDNkODJmZGNjNzEyZjRjZjMyYiIsImV4cCI6MTY2MzM5MzAxMSwiaWF0IjoxNjU4MjA5MDExfQ.QA5ERldGsJAbMg0uqfz1HrIWH_ziwq2g7uD3mGZ2atg';
+        const accountName = 'abc2id';
+        localStorage.setItem('token', token);
+        const getToken = localStorage.getItem('token');
+
+        try {
+            const res = await axios.get(`${url}/post/${accountName}/userpost`, {
+                method: 'GET',
+                headers: {
+                    'Authorization': `Bearer ${getToken}`,
+                    'Content-type': 'application/json',
+                },
+            });
+            setContent(res.data.post[0].content);
+        } catch (error) {
+            console.log(error);
+        }
+    };
+    renderPost();
+    return (
+        <>
+            {/* 이 자리에 게시물 상세가 불러와집니다 */}
+            <h1
+                style={{
+                    display: 'block',
+                    width: '400px',
+                    margin: '10px auto',
+                }}
+            >
+                게시물 내용 : {content}
+            </h1>
+            <CommentList />
+        </>
+    );
+};
+
+export default TestPost;


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

피드에서 댓글 버튼을 클릭하면 게시물 아래에 나오는 댓글 리스트 기능을 구현했습니다
![image](https://user-images.githubusercontent.com/84116709/179871888-261d1951-a5ea-471a-872f-9d3b4c46cb1b.png)

- 피드에 있는 게시물 아래 댓글 버튼 클릭시 나오는 화면입니다   
임시로 실제 서버에 올라간 게시글의 content만 통신으로 가져왔습니다
- 댓글이 새로 추가될 때마다 화면이 리렌더링됩니다
- 댓글 작성자의 프로필, 유저 네임과 작성 시간 (방금 전, ~분 전, ~시간 전, ~일 전)이 뜹니다
- 모달 기능 구현은 민경님과 상의해서 나중에 붙일 예정입니다
- 후에 전체 완성이 되면, 프로필과 유저 네임 클릭시 해당 사용자의 프로필로 이동되도록 추가해야합니다
- 댓글 작성 기능은 다시 PR 하겠습니다
