### PR TITLE
Feat: 미술계 소식 페이지 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,10 +13,6 @@
     },
     "plugins": ["react"],
     "rules": {
-<<<<<<< HEAD
         "react/prop-types": "off"
-=======
-      "react/prop-types": "off"
->>>>>>> upstream/main
     }
 }

--- a/src/pages/news/News.jsx
+++ b/src/pages/news/News.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import TopBasicNav from '../../components/nav/TopBasicNav';
+import NewsList from './NewsList';
+
+const News = () => {
+    return (
+        <>
+            <TopBasicNav navTitle="새로운 소식" />
+            <NewsList />
+        </>
+    );
+};
+
+export default News;

--- a/src/pages/news/NewsCard.jsx
+++ b/src/pages/news/NewsCard.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import styles from './NewsCard.module.css';
+
+const NewsCard = ({ newsImg, newsContent }) => {
+    return (
+        <li className={styles.newscard_box}>
+            <img
+                src={newsImg}
+                alt={`${newsContent}`}
+                className={styles.newscard_img}
+            />
+            <strong className={styles.newscard_content}>{newsContent}</strong>
+        </li>
+    );
+};
+
+export default NewsCard;

--- a/src/pages/news/NewsCard.module.css
+++ b/src/pages/news/NewsCard.module.css
@@ -1,0 +1,16 @@
+.newscard_box {
+    margin-bottom: 5rem;
+}
+
+.newscard_box .newscard_img {
+    display: block;
+    width: 40rem;
+    height: 30rem;
+    border-radius: 1rem;
+    margin-bottom: 2rem;
+}
+
+.newscard_box .newscard_content {
+    font-size: 2rem;
+    font-weight: 700;
+}

--- a/src/pages/news/NewsList.jsx
+++ b/src/pages/news/NewsList.jsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import styles from './NewsList.module.css';
+import NewsCard from './NewsCard';
+
+const NewsList = () => {
+    const [newsList, setNewsList] = useState([]);
+
+    useEffect(() => {
+        async function getNews() {
+            const url = 'https://mandarin.api.weniv.co.kr';
+            const token =
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyZDdiMDkwMTdhZTY2NjU4MTdjODJkOCIsImV4cCI6MTY2MzQ4NzEzNywiaWF0IjoxNjU4MzAzMTM3fQ.61cAggF_ueVIWK80RD14HqmDNNJn_N3maKssZ9LMfC8';
+            const accountName = 'admin_youth';
+            localStorage.setItem('token', token);
+            const getToken = localStorage.getItem('token');
+
+            try {
+                const res = await axios.get(
+                    `${url}/post/${accountName}/userpost`,
+                    {
+                        method: 'GET',
+                        headers: {
+                            'Authorization': `Bearer ${getToken}`,
+                            'Content-type': 'application/json',
+                        },
+                    }
+                );
+                setNewsList(res.data.post);
+            } catch (error) {
+                console.log(error);
+            }
+        }
+        getNews();
+    }, []);
+
+    return (
+        <section>
+            <h1 className={styles.news_title}>
+                매주 <span className={styles.title_span}>업데이트</span> 되는
+                <span className={styles.title_span}>미술계 소식</span>을
+                만나보세요!
+            </h1>
+            <ul className={styles.news_box}>
+                {newsList &&
+                    newsList.map((news) => {
+                        return (
+                            <NewsCard
+                                newsImg={news?.image}
+                                newsContent={news?.content}
+                                key={news?.id}
+                            />
+                        );
+                    })}
+            </ul>
+        </section>
+    );
+};
+
+export default NewsList;

--- a/src/pages/news/NewsList.module.css
+++ b/src/pages/news/NewsList.module.css
@@ -1,0 +1,18 @@
+.news_title {
+    margin: 6rem 0 2rem 0;
+    font-size: 3rem;
+    font-weight: 700;
+    color: var(--logo-black);
+    text-align: center;
+}
+
+.news_title .title_span {
+    font-size: 3.5rem;
+    color: var(--logo-yellow);
+    text-shadow: 1px 1px 1px var(--logo-black);
+}
+
+.news_box {
+    width: 40rem;
+    margin: 0 auto;
+}


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [x] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

**미술계 소식 페이지 추가했습니다**   
![image](https://user-images.githubusercontent.com/84116709/180118147-6b8dcfa5-cbed-4868-96f8-372ca5235282.png)   
![image](https://user-images.githubusercontent.com/84116709/180118178-568744b6-e849-4a2a-87e1-ac16885f2386.png)   

- 위에 기본 Navbar가 있고, 아래에 NewsList, 그 안에 NewsCard가 있습니다
- `@admin_youth 계정`을 별도로 만들었고, 해당 계정에 있는 포스팅의 이미지와 글을 가져왔습니다
- 이미지 클릭시 관련 페이지 이동 처리를 하려했으나, map으로 코드를 수정하다보니   
링크 이동 이벤트를 동적으로 구현하려면 링크간 어느정도 통일성이 필요한데   
페이지마다 링크가 제각각이라 어려움이 있습니다   
map을 사용하지 않고 각각 div를 만들면 a 링크 연결도 가능하지만 그렇게 하면 코드가 너무 길어져 우선 이렇게 올립니다
- eslint 파일 오류 수정 포함되어있습니다