### PR TITLE
Feat: 프로필설정 사진 미리보기 기능 추가, Fix: 프로필설정 사진첨부 input type="file"로 변경

### DIFF
--- a/src/components/membership/JoinMembership.jsx
+++ b/src/components/membership/JoinMembership.jsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './JoinMembership.module.css';
 import LoginInput from '../LoginInput';
 import Title from '../login/Title';
 
 function JoinMembership() {
+    const [file, setFile] = useState('');
+    console.log(file);
+    const backgroundstyle = {
+        backgroundImage: `url('${file}')`,
+    };
+
     return (
         <>
             <section className={styles.joinMembership_body}>
@@ -11,16 +17,23 @@ function JoinMembership() {
                 <span className={styles.joinMembership_titleSpan}>
                     나중에 언제든지 변경할 수 있습니다.
                 </span>
-                <div className={styles.joinMembership_uploadImg}>
+                <div className={styles.joinMembership_uploadContainer}>
+                    {/* {file === null ? ( */}
+                    <div className={styles.preview} style={backgroundstyle} />
+                    {/* ) : null} */}
+
                     <label
-                        htmlFor="input-file"
+                        htmlFor="input_file"
                         className={styles.joinMembership_fileImg}
                     />
                     <input
                         type="file"
-                        id="input-file"
+                        id="input_file"
                         style={{ display: 'none' }}
-                    ></input>
+                        onChange={(e) => {
+                            setFile(URL.createObjectURL(e.target.files[0]));
+                        }}
+                    />
                 </div>
                 <LoginInput
                     title={'사용자 이름'}

--- a/src/components/membership/JoinMembership.jsx
+++ b/src/components/membership/JoinMembership.jsx
@@ -12,7 +12,15 @@ function JoinMembership() {
                     나중에 언제든지 변경할 수 있습니다.
                 </span>
                 <div className={styles.joinMembership_uploadImg}>
-                    <div className={styles.joinMembership_fileImg}></div>
+                    <label
+                        htmlFor="input-file"
+                        className={styles.joinMembership_fileImg}
+                    />
+                    <input
+                        type="file"
+                        id="input-file"
+                        style={{ display: 'none' }}
+                    ></input>
                 </div>
                 <LoginInput
                     title={'사용자 이름'}

--- a/src/components/membership/JoinMembership.module.css
+++ b/src/components/membership/JoinMembership.module.css
@@ -14,7 +14,7 @@
     margin: 0 auto;
 }
 
-.joinMembership_uploadImg {
+.joinMembership_uploadContainer {
     position: relative;
     background-image: url(../../assets/basic-profile-img-.png);
     width: 100%;
@@ -23,6 +23,16 @@
     background-position: center;
     background-size: 14vh;
     margin: 10px 0;
+}
+
+.preview {
+    width: 16vh;
+    height: 16vh;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 16vh;
+    margin: 10px auto;
+    border-radius: 50%;
 }
 
 .joinMembership_fileImg {
@@ -35,10 +45,6 @@
     background-repeat: no-repeat;
     background-position: center;
     background-size: 5vh;
-}
-
-#input-file {
-    display: none;
 }
 
 .joinMembership_btn {

--- a/src/components/membership/JoinMembership.module.css
+++ b/src/components/membership/JoinMembership.module.css
@@ -37,6 +37,10 @@
     background-size: 5vh;
 }
 
+#input-file {
+    display: none;
+}
+
 .joinMembership_btn {
     background-color: var(--btn-gray);
     border: initial;


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [x] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용
1. 프로필설정 사진첨부 부분을 나중에 사진이 들어갈 때를 생각하여,
div태그에서 input type="file"로 변경하였습니다.

```jsx
                <div className={styles.joinMembership_uploadImg}>
                    <label
                        htmlFor="input-file"
                        className={styles.joinMembership_fileImg}
                    />
                    <input
                        type="file"
                        id="input-file"
                        style={{ display: 'none' }}
                    ></input>
                </div>
```

     
2. 프로필설정 사진첨부 미리보기 기능을 추가하였습니다.
![미리보기](https://user-images.githubusercontent.com/76866502/180476441-a937b993-5bc6-40a8-ae79-7252256ab18b.gif)

