### PR TITLE
Fix: PageRouter 파일에 profile path 중복 수정

### DIFF
--- a/src/pages/PageRouter.jsx
+++ b/src/pages/PageRouter.jsx
@@ -28,7 +28,6 @@ function PageRouter() {
                 path="/post/62d9039917ae66658183d2c8"
                 element={<PostDetail />}
             />
-            <Route path="/profile" element={<TabMenu img={'profileImg'} />}>
             <Route path="/profile" element={<UserProfile />}>
                 <Route path="followers" element={<FollowersList />} />
                 <Route path="followings" element={<FollowingsList />} />


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

page router에 같은 경로에 코드가 두 줄이라 에러가 생겼더라구요! 요거 한 줄 수정해서 바로 PR 올립니다~!
