### PR TITLE
Fix: 게시물 작성시 이미지 에러 핸들링

### DIFF
--- a/src/pages/postUpload/PostUploadForm.jsx
+++ b/src/pages/postUpload/PostUploadForm.jsx
@@ -6,45 +6,72 @@ import styles from './PostUploadForm.module.css';
 import axios from 'axios';
 
 const PostUploadForm = () => {
+    let imgUrlLists = [];
+    const [state, setState] = useState(false);
+    const [txt, setTxt] = useState('');
+    const [showImgs, setShowImgs] = useState([]);
+    const MAX_UPLOAD = 3;
+
     const inpRef = useRef();
     const onPicBtnClick = () => {
         inpRef.current.click();
     };
-    const [state, setState] = useState(false);
 
-    const [txt, setTxt] = useState('');
     const handleTxt = (event) => {
         setTxt(event.target.value);
     };
 
-    const MAX_UPLOAD = 3;
-    const [showImages, setShowImages] = useState([]);
-    const handleAddImages = (event) => {
-        const imageFiles = event.target.files;
-        let imageUrlLists = [...showImages];
-        for (let i = 0; i < imageFiles.length; i++) {
-            const currentImageUrl = URL.createObjectURL(imageFiles[i]);
-            imageUrlLists.push(currentImageUrl);
+    const uploadImg = async () => {
+        let formData = new FormData();
+        const imgFiles = inpRef.current.files;
+        for (let i = 0; i < imgFiles.length; i++) {
+            const file = imgFiles[i];
+            formData.append('image', file);
         }
+        const res = await axios({
+            method: 'post',
+            url: 'https://mandarin.api.weniv.co.kr/image/uploadfiles',
+            data: formData,
+        });
 
-        if (imageUrlLists.length > MAX_UPLOAD) {
-            imageUrlLists = imageUrlLists.slice(0, 3);
-            alert('이미지 업로드는 3개까지만 가능합니다.');
-        }
-        setShowImages(imageUrlLists);
+        console.log(res.data);
+        const imgUrls = res.data
+            .map((file) => 'https://mandarin.api.weniv.co.kr/' + file.filename)
+            .join();
+        console.log(imgUrls);
+        return imgUrls;
     };
 
+    const handleAddImages = (event) => {
+        if (event.target.files) {
+            const filesArray = Array.from(event.target.files).map((file) =>
+                URL.createObjectURL(file)
+            );
+            imgUrlLists.push(...filesArray);
+            setShowImgs((prevImgs) => prevImgs.concat(filesArray));
+        }
+        console.log(imgUrlLists);
+        const imgFiles = inpRef.current.files;
+        if (imgFiles.length > MAX_UPLOAD) {
+            alert('이미지 업로드는 3개까지만 가능합니다.');
+            imgUrlLists = imgUrlLists.slice(0, 3);
+            setShowImgs(imgUrlLists);
+        }
+        Array.from(event.target.files).map((file) => URL.revokeObjectURL(file));
+    };
+    console.log(showImgs);
+
     const handleDeleteImage = (id) => {
-        setShowImages(showImages.filter((_, index) => index !== id));
+        setShowImgs(showImgs.filter((_, index) => index !== id));
     };
 
     useEffect(() => {
-        if (txt.length > 0 || showImages.length > 0) {
+        if (txt.length > 0 || showImgs.length > 0) {
             setState(true);
         } else {
             setState(false);
         }
-    }, [txt, showImages]);
+    }, [txt, showImgs]);
 
     // 임시로 token과 사용자를 설정하였습니다. 로그인 기능 완성후 수정 예정
 
@@ -56,14 +83,14 @@ const PostUploadForm = () => {
         localStorage.setItem('token', token);
         const getToken = localStorage.getItem('token');
         console.log(getToken);
-
+        const res = uploadImg();
         try {
             await axios.post(
                 `${url}/post`,
                 {
                     post: {
                         content: `${txt}`,
-                        image: `${showImages.join(',')}`,
+                        image: await res,
                     },
                 },
                 {
@@ -78,6 +105,7 @@ const PostUploadForm = () => {
         }
         // 나중에 useNavigate() 추가하여 프로필 경로로 이동
         // navigate('');
+        // console.log(imageUrlLists);
     };
 
     return (
@@ -108,7 +136,7 @@ const PostUploadForm = () => {
                     />
                 </div>
                 <div className={styles.preview_pics}>
-                    {showImages.map((image, id) => (
+                    {showImgs.map((image, id) => (
                         <div key={id} className={styles.preview_div}>
                             <img
                                 src={image}

--- a/src/pages/postUpload/PostUploadForm.jsx
+++ b/src/pages/postUpload/PostUploadForm.jsx
@@ -4,9 +4,11 @@ import TopUploadNav from '../../components/nav/TopUploadNav';
 import Nav from '../../components/nav/Nav';
 import styles from './PostUploadForm.module.css';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 const PostUploadForm = () => {
     let imgUrlLists = [];
+    const navigate = useNavigate();
     const [state, setState] = useState(false);
     const [txt, setTxt] = useState('');
     const [showImgs, setShowImgs] = useState([]);
@@ -77,6 +79,7 @@ const PostUploadForm = () => {
 
     const createPost = async (e) => {
         e.preventDefault();
+
         const url = 'https://mandarin.api.weniv.co.kr';
         const token =
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyY2FkNjA3ODJmZGNjNzEyZjQzN2QyZCIsImV4cCI6MTY2MjcxMDYxOCwiaWF0IjoxNjU3NTI2NjE4fQ.w47m557FRqRQhF8PGM_VUxF10mFtDexYJIxqUasFQ7I';
@@ -100,12 +103,10 @@ const PostUploadForm = () => {
                     },
                 }
             );
+            navigate('/profile');
         } catch (error) {
             console.log(error);
         }
-        // 나중에 useNavigate() 추가하여 프로필 경로로 이동
-        // navigate('');
-        // console.log(imageUrlLists);
     };
 
     return (


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [x] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

### 버그 수정
post 전송은 되나, 이미지가 페이지에서 보이지 않고 alt 값으로 표시되는 에러를 해결했습니다   
![image](https://user-images.githubusercontent.com/84116709/180922267-071f7b9e-322c-41b7-ba0c-0adb94c93e63.png)   

- 기존 코드에서 post 전송은 잘 되고있었지만, 이미지가 표시되지 않는 에러가 있었습니다

- `미리보기 렌더링시 필요한 URL(blob)`과 `서버에 전송할 이미지 주소(서버에 이미지 등록시 반환됨)`를 분리해서   
사용해야 하는데, 이 두가지를 혼용해서 사용하여 발생한 문제

- 미리보기 이미지를 렌더링할 때 사용하는 `handleAddImages` 핸들러 함수와,   
이미지를 서버에 등록하고 주소를 얻기 위해 필요한 `uploadImg` 함수를 별도로 분리했습니다

### 신규 기능
- post 업로드 후, 프로필 페이지로 이동합니다
