### PR TITLE
Feat: 뉴스 페이지 연결

### DIFF
--- a/src/pages/PageRouter.jsx
+++ b/src/pages/PageRouter.jsx
@@ -12,12 +12,13 @@ import Search from './Search';
 import PostDetail from './postDetail/PostDetail';
 import UserProfile from './userprofile/UserProfile';
 import PostUpload from './postUpload/PostUpload';
+import News from './news/News';
 
 function PageRouter() {
     return (
         <Routes>
             <Route path="/" element={<Home />} />
-            <Route path="/news" element={<TabMenu img={'newsImg'} />} />
+            <Route path="/news" element={<News />} />
             <Route path="/post">
                 <Route path="upload" element={<PostUpload />} />
                 <Route path="edit" element={<TabMenu img={'uploadImg'} />} />

--- a/src/pages/news/News.jsx
+++ b/src/pages/news/News.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import Nav from '../../components/nav/Nav';
 import TopBasicNav from '../../components/nav/TopBasicNav';
 import NewsList from './NewsList';
 
 const News = () => {
     return (
         <>
-            <TopBasicNav navTitle="새로운 소식" />
+            <Nav>
+                <TopBasicNav navTitle="새로운 소식" />
+            </Nav>
             <NewsList />
         </>
     );


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

하단 탭에 뉴스 페이지 연결했습니다   
![chrome-capture-2022-6-26](https://user-images.githubusercontent.com/84116709/180930614-7cab9ed4-9a1d-40f0-8abc-2a47f64a2069.gif)   

- 하단 탭에 뉴스 페이지 연결   
- `TopUploadNav`에 `<Nav>` 태그 추가해서 감싸줌   
