### PR TITLE
DesignCSS: 상품리스트 width값 설정, 가운데 정렬

### DIFF
--- a/src/components/Product.js
+++ b/src/components/Product.js
@@ -17,11 +17,16 @@ const ContentWrap = styled.li`
     width: fit-content;
     text-align: start;
     background-color: #fff;
+    margin-right: 10px;
+    &:last-child {
+        margin-right: 0;
+    }
 `;
 
 const ProductImg = styled.img`
     width: 140px;
     height: 90px;
+    object-fit: cover;
     border-radius: 8px;
     margin-bottom: 6px;
 `;

--- a/src/components/Profile.module.css
+++ b/src/components/Profile.module.css
@@ -1,10 +1,12 @@
 .all_warpper {
     min-width: 390px;
     display: flex;
+    background-color: #fff;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     padding: 30px 0 26px;
+    border-bottom: 0.5px solid #dbdbdb;
 }
 
 .all_warpper .top_warpper {

--- a/src/pages/userprofile/UserProfile.jsx
+++ b/src/pages/userprofile/UserProfile.jsx
@@ -86,7 +86,7 @@ function UserProfile() {
     };
 
     return (
-        <>
+        <section className={styles.user_profile_section}>
             <Nav>
                 <TopBasicNav
                     title={'youth-gallery 홈'}
@@ -96,13 +96,17 @@ function UserProfile() {
             <div className={styles.user_profile_wrap}>
                 <Profile profileData={profileData} />
                 <section className={styles.product_section}>
-                    <h2 className={styles.title}>판매 중인 상품</h2>
-                    <ul className={styles.item_warp}>
-                        {productList.map((_, i) => {
-                            // eslint-disable-next-line react/jsx-key
-                            return <Product productList={productList} i={i} />;
-                        })}
-                    </ul>
+                    <div className={styles.product_list_warp}>
+                        <h2 className={styles.title}>판매 중인 상품</h2>
+                        <ul className={styles.item_warp}>
+                            {productList.map((_, i) => {
+                                return (
+                                    // eslint-disable-next-line react/jsx-key
+                                    <Product productList={productList} i={i} />
+                                );
+                            })}
+                        </ul>
+                    </div>
                 </section>
                 <section className={styles.post_section}>
                     <h2 className={styles.ir}>작성한 게시글</h2>
@@ -123,7 +127,10 @@ function UserProfile() {
             <ButtonModalActive
                 propState={showModal}
                 propsCloseFunc={closeModal}
-                postModalValues={{ values: ['설정 및 개인정보', '로그아웃'] , type:'logout'}}
+                postModalValues={{
+                    values: ['설정 및 개인정보', '로그아웃'],
+                    type: 'logout',
+                }}
                 innerAlertValues={{
                     title: '로그아웃 하시겠어요? ',
                     rightText: '로그아웃',
@@ -131,7 +138,7 @@ function UserProfile() {
                 }}
             />
             <TabMenu img={'profileImg'} />
-        </>
+        </section>
     );
 }
 

--- a/src/pages/userprofile/UserProfile.module.css
+++ b/src/pages/userprofile/UserProfile.module.css
@@ -8,16 +8,26 @@
     overflow: hidden;
 }
 
+.user_profile_section {
+    background-color: #f2f2f2;
+}
+
 .user_profile_wrap {
     margin: 60px 0;
 }
 
 .product_section {
-    max-width: 400px;
+    width: 100%;
+    background-color: #fff;
     border-top: 0.5px solid #dbdbdb;
     border-bottom: 0.5px solid #dbdbdb;
     padding: 20px 0 20px 21px;
-    margin: 0 auto 6px auto;
+    margin: 6px auto;
+}
+
+.product_section .product_list_warp {
+    max-width: 400px;
+    margin: 0 auto;
 }
 
 .product_section .title {
@@ -34,7 +44,9 @@
 
 .post_section {
     display: flex;
+    background-color: #fff;
     flex-direction: column;
     align-items: center;
     padding: 16px 0 30px;
+    border-top: 0.5px solid #dbdbdb;
 }

--- a/src/pages/userprofile/UserProfile.module.css
+++ b/src/pages/userprofile/UserProfile.module.css
@@ -13,11 +13,11 @@
 }
 
 .product_section {
-    width: 100%;
+    max-width: 400px;
     border-top: 0.5px solid #dbdbdb;
     border-bottom: 0.5px solid #dbdbdb;
     padding: 20px 0 20px 21px;
-    margin-bottom: 6px;
+    margin: 0 auto 6px auto;
 }
 
 .product_section .title {
@@ -29,7 +29,7 @@
 .product_section .item_warp {
     display: flex;
     flex-wrap: nowrap;
-    overflow: scroll;
+    overflow-x: scroll;
 }
 
 .post_section {


### PR DESCRIPTION
## 작업 분류

-   [ ] 신규 기능
-   [x] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용
![localhost_3000_ (4)](https://user-images.githubusercontent.com/100986977/181005838-e015e2f4-b531-41e3-a537-80466e567a1b.png)



- width값 주고 가운데 정렬했습니다.
- scroll 바 x, y축 다 뜨던 것 x축으로만 뜨게 수정했습니다.
- 각 section이 떨어져있어야 해서 추가적으로 section과 div를 넣어  분리 시키고 난 뒤 background에 `#fff` 값을 주었습니다.
- 전체 배경에는 회색을 `#f2f2f2`를 주었습니다.
- Product 컴포넌트에서 margin-right 값을 주어 상품 리스트 간의 간격을 띄웠습니다.
