### PR TITLE
Feat: 홈 피드에  '유저를 검색해 팔로우 해보세요' 페이지 표시

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import axios from 'axios';
 import TabMenu from '../components/tab/TabMenu';
 import Nav from '../components/nav/Nav';
 import TopMainNav from '../components/nav/TopMainNav';
+import NonFollowing from './NonFollowing';
 
 const Div = styled.div`
     display: flex;
@@ -15,7 +16,7 @@ const Div = styled.div`
 `;
 
 function Home() {
-    const [posts, setPosts] = useState([]);
+    const [posts, setPosts] = useState({});
 
     const url = 'https://mandarin.api.weniv.co.kr';
     const getToken = localStorage.getItem('token');
@@ -32,17 +33,22 @@ function Home() {
             .then((response) => setPosts(response))
             .catch((error) => console.log(error.message));
     }, []);
-    console.log(posts);
+    console.log(posts && posts);
+    console.log(posts.data && posts.data.posts.length);
+
     return (
         <>
             <Nav>
                 <TopMainNav title={'youth-gallery 홈'} />
             </Nav>
             <Div>
-                {posts.data &&
+                {posts.data && posts.data.posts.length !== 0 ? (
                     posts.data.posts.map((post) => (
                         <HomePost key={post.id} datas={post} />
-                    ))}
+                    ))
+                ) : (
+                    <NonFollowing />
+                )}
             </Div>
             <TabMenu img={'homeImg'} />
         </>


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

홈 피드에 나타내는 게시글이 없을 시 '유저를 검색해 팔로우 해보세요' 페이지 표시할 수 있도록 코드 변경하였습니다.
![image](https://user-images.githubusercontent.com/67677374/181342762-fc18c33f-df84-4308-ae29-3733e9d7e69d.png)

-   왼쪽 페이지가 보여지는 게시글이 없는 계정, 오른쪽이 팔로우하고 있는게시글이 있는 계정입니다.
-   현재 서버에서 데이터를 받아오기 전에 배열에 값이 없을 경우 잠시 검색하세요 페이지가 떴다가 사라집니다. 이 부분을 어떻게 개선할 지 현재 아이디어가 떠오르지 않아 수정을 못하였으나 다른 기능을 처리 한 이후에 다시 생각해보도록 하겠습니다. 혹시 좋은 아이디어가 있다면 댓글 부탁드립니다!
