### PR TITLE
Fix: tabMenu에서 프로필 클릭 시 myprofile로 이동

### DIFF
--- a/src/components/tab/TabMenu.jsx
+++ b/src/components/tab/TabMenu.jsx
@@ -61,7 +61,6 @@ const Span = styled.span`
 `;
 
 const menuRendering = (img) => {
-  const getAccountName = localStorage.getItem('accountname');
     const result = [];
     const imgIcon = [
         { key: 'homeImg', value: homeImg },
@@ -71,7 +70,7 @@ const menuRendering = (img) => {
     ];
     const imgIconFill = [homeImgFill, newsImgFill, postImg, profileImgFill];
     const tabTitle = ['홈', '소식', '게시물 작성', '프로필'];
-    const link = ['/', '/news', '/post/upload', `/profile/${getAccountName}`];
+    const link = ['/', '/news', '/post/upload', `/myprofile`];
     for (let i = 0; i < 4; i++) {
         result.push(
             <StyledLink to={link[i]} key={i}>

--- a/src/pages/PageRouter.jsx
+++ b/src/pages/PageRouter.jsx
@@ -28,6 +28,7 @@ function PageRouter() {
             {/* 임시로 게시물 id 지정 
             나중에 /post/:id 로 넣으면됨*/}
             <Route path="/post/:username/:post_id" element={<PostDetail />} />
+            <Route path="/myprofile" element={<UserProfile />} />
             <Route path="/profile/:accountname" element={<UserProfile />}>
                 <Route path="followers" element={<FollowersList />} />
                 <Route path="followings" element={<FollowingsList />} />


### PR DESCRIPTION
## 작업 분류

-   [ ] 신규 기능
-   [ ] 버그 수정
-   [x] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용
![프로필누르면내프로필로](https://user-images.githubusercontent.com/100986977/181427070-3abc6e53-3da5-4e90-a9c2-528062540eb3.gif)

프로필을 클릭하면 /myprofile로 이동하도록 수정하였습니다.

추후에 다른 사람 프로필 누르면 다른 사람 계정으로 넘어가는 것도 구현하겠습니다.
