### PR TITLE
Feat: 검색되는 프로필 중에 엑박사진 기본 사진으로 처리

### DIFF
--- a/src/components/UserSearch.jsx
+++ b/src/components/UserSearch.jsx
@@ -15,11 +15,15 @@ function UserSearch({ userImg, username, accountname, keyword }) {
             <>{item}</>
         );
     };
+
+    const handleImgError = (e) => {
+        e.target.src = basicProfileImg;
+    };
     return (
         // 추후에 아이디 프로필 페이지로 연결
         <StyledLink to={'/profile/' + accountname}>
             <Div>
-                <ProfileImg src={userImg || basicProfileImg} />
+                <ProfileImg src={userImg} onError={handleImgError} />
                 <UserInfoWarp>
                     <UserName>
                         <ColoredItem


### PR DESCRIPTION
## 작업 분류

-   [x] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

이미지가 깨지는 검색 프로필을 기본 이미지로 나오게 처리했습니다.
![image](https://user-images.githubusercontent.com/67677374/181455926-7baac993-d02b-4e9d-9607-27602e840a51.png)

