### PR TITLE
Fix: 팔로워리스트 고정값 변경, Fix: 내 계정일 때 타인 계정일 때 프로필 이동 링크 분기

### DIFF
--- a/src/components/UserFollow.js
+++ b/src/components/UserFollow.js
@@ -6,8 +6,15 @@ import SearchCancelButton from './button/SearchCancelButton';
 
 function UserFollow({ followers, i }) {
     // const [followState] = useState(false);
+    const getAccountName = localStorage.getItem('accountname');
     return (
-        <Li>
+        <Li
+            to={
+                getAccountName === followers[i].accountname
+                    ? '/myprofile'
+                    : '/profile/' + followers[i].accountname
+            }
+        >
             <ProfileImg src={followers[i].image} />
             <UserInfoWarp>
                 <UserName>{followers[i].accountname}</UserName>

--- a/src/pages/FollowersList.jsx
+++ b/src/pages/FollowersList.jsx
@@ -6,17 +6,19 @@ import UserFollow from '../components/UserFollow';
 
 function FollowersList() {
     const [followers, setFollowers] = useState([]);
-    const token =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYyY2JjNTJiODJmZGNjNzEyZjQzODgyOSIsImV4cCI6MTY2MjcxMjQ1MSwiaWF0IjoxNjU3NTI4NDUxfQ.bnhQqSrauikpfrLKP6OXl2HMdizZdeM1TclnNTr1OXk';
+    const getToken = localStorage.getItem('token');
 
     useEffect(() => {
         axios
-            .get('https://mandarin.api.weniv.co.kr/profile/0002/follower', {
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'Content-type': 'application/json',
-                },
-            })
+            .get(
+                'https://mandarin.api.weniv.co.kr/profile/:accountname/follower',
+                {
+                    headers: {
+                        'Authorization': `Bearer ${getToken}`,
+                        'Content-type': 'application/json',
+                    },
+                }
+            )
             .then((res) => {
                 // console.log(res);
                 setFollowers(res.data);


### PR DESCRIPTION
## 작업 분류

-   [ ] 신규 기능
-   [ ] 버그 수정
-   [x] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

팔로워 리스트 token 값과 accountname 값을 변경하였습니다.
그리고 내 계정일 때는 myprofile로 타인 계정일 때는 profile/:accountname 으로 분기 했습니다.
