### PR TITLE
DesignCSS: myprofile이외의 BasicNav에서 모달 버튼 숨김

### DIFF
--- a/src/components/nav/TopBasicNav.jsx
+++ b/src/components/nav/TopBasicNav.jsx
@@ -39,9 +39,9 @@ function TopBasicNav({ title, openModalProp }) {
                 <ArrowLeftButton name="back" onClick={handleGoBack} />
                 <NavTitle>{title}</NavTitle>
             </Warpper>
-            {title === 'Followers' ? null : (
+            {location.pathname === '/myprofile' ? (
                 <ButtonModal openModalProp={openModalProp} />
-            )}
+            ) : null}
         </>
     );
 }


### PR DESCRIPTION
## 작업 분류

-   [ ] 신규 기능
-   [ ] 버그 수정
-   [x] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

myprofile이외의 BasicNav에서 모달 버튼이 뜨지 않게 바꾸었습니다.
