### PR TITLE
Fix: 타인 계정 게시글 점 세개 버튼 클릭 시 신고하기로 변경

### DIFF
--- a/src/components/UserPost.jsx
+++ b/src/components/UserPost.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import ButtonModal from './modal/ButtonModal';
 import ButtonModalActive from './modal/ButtonModalActive';
 import axios from 'axios';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import PostHeartBtn from './PostForm/PostHeartBtn';
 import PostComment from './PostForm/PostComment';
 import PostImg from './PostForm/PostImg';
@@ -70,6 +70,7 @@ const UserPost = ({ postList, profileData, i }) => {
         console.log(propState);
         setShowModal(propState);
     };
+    const { myprofile } = useParams();
 
     const closeModal = (props) => {
         setShowModal(props);
@@ -95,6 +96,12 @@ const UserPost = ({ postList, profileData, i }) => {
             console.log(error);
         }
         console.log(post_id);
+    };
+
+    // 신고 그냥 기능은 없는...
+    const declaration = () => {
+        alert('신고되었습니다.');
+        setShowModal(false);
     };
 
     return (
@@ -130,19 +137,34 @@ const UserPost = ({ postList, profileData, i }) => {
                     </HomePostDate>
                 </div>
             </HomePostLi>
-            <ButtonModalActive
-                propState={showModal}
-                propsCloseFunc={closeModal}
-                postModalValues={{
-                    values: ['삭제', '수정'],
-                }}
-                post_id={post_id}
-                innerAlertValues={{
-                    title: '게시물을 삭제할까요? ',
-                    rightText: '삭제',
-                    rightBtnPropFunc: deletePost,
-                }}
-            />
+            {myprofile ? (
+                <ButtonModalActive
+                    propState={showModal}
+                    propsCloseFunc={closeModal}
+                    postModalValues={{
+                        values: ['삭제', '수정'],
+                    }}
+                    innerAlertValues={{
+                        title: '게시물을 삭제할까요? ',
+                        rightText: '삭제',
+                        rightBtnPropFunc: deletePost,
+                    }}
+                />
+            ) : (
+                <ButtonModalActive
+                    propState={showModal}
+                    propsCloseFunc={closeModal}
+                    postModalValues={{
+                        values: ['신고하기'],
+                    }}
+                    post_id={post_id}
+                    innerAlertValues={{
+                        title: '게시물을 신고할까요? ',
+                        rightText: '신고',
+                        rightBtnPropFunc: declaration,
+                    }}
+                />
+            )}
         </>
     );
 };


### PR DESCRIPTION
## 작업 분류

-   [ ] 신규 기능
-   [x] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [ ] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

![타인계정 신고](https://user-images.githubusercontent.com/100986977/181873238-991d333b-247a-4c9d-b08e-e46a0fd4772f.gif)


타인 계정과 내 계정 게시글 점 세개 버튼 눌렀을 시 같은 모달이 뜨던 것을 변경하였습니다.

close #137 
