### PR TITLE
DesignCSS: 사용가능한 이메일 메시지 띄울 시 색깔 변경

### DIFF
--- a/src/components/join/EmailJoin.jsx
+++ b/src/components/join/EmailJoin.jsx
@@ -148,7 +148,16 @@ function EmailJoin() {
                             placeholder="이메일 주소를 입력해주세요."
                             onChange={handleJoinId}
                         />
-                        <div className={styles.join_error}>{emailMsg}</div>
+                        {/* <div className={styles.join_error}>{emailMsg}</div> */}
+                        <div
+                            className={
+                                joinEmailConfirm
+                                    ? styles.join_success
+                                    : styles.join_error
+                            }
+                        >
+                            {emailMsg}
+                        </div>
 
                         <label className={styles.join_label} htmlFor="input_pw">
                             비밀번호

--- a/src/components/join/EmailJoin.module.css
+++ b/src/components/join/EmailJoin.module.css
@@ -20,6 +20,11 @@
     font-size: 1.2rem;
     margin-bottom: 16px;
 }
+.join_success {
+    color: var(--success-green);
+    font-size: 1.2rem;
+    mask-border: 16px;
+}
 
 .join_btn {
     background-color: var(--btn-gray);


### PR DESCRIPTION
## 작업 분류

-   [ ] 신규 기능
-   [ ] 버그 수정
-   [ ] 기능 개선
-   [ ] 리팩토링 및 구조 변경
-   [x] 기타 (문서, CI/CD 워크플로 변경 등)

## 작업 내용

- 사용가능한 이메일 메시지 띄울 시에는 초록색으로  색깔 변경하였습니다.   
- 
[이미지]
![image](https://user-images.githubusercontent.com/76866502/182015715-cf875c0c-5a99-4874-80a1-31fe0077758f.png)
